### PR TITLE
feat: add `KeyIdMapping` trait

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  path_filters:
+    - "!vendor/**"
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+    base_branches:
+      - "master"
+      - "release/.*"
+chat:
+  auto_reply: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 default-members = ["lib"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/hopr-types"

--- a/primitive/src/traits.rs
+++ b/primitive/src/traits.rs
@@ -1,5 +1,24 @@
 use crate::errors::{GeneralError, GeneralError::ParseError, Result};
 
+/// Trait that defines 1:1 mapper between key identifiers and public keys.
+///
+/// This is used to uniquely map between short public key identifiers (commonly used in the Sphinx header),
+/// and actual routing addresses (public keys) of the nodes.
+pub trait KeyIdMapping<Id, K> {
+    /// Maps public key to its unique identifier.
+    fn map_key_to_id(&self, key: &K) -> Option<Id>;
+    /// Maps public key identifier to the actual public key.
+    fn map_id_to_public(&self, id: &Id) -> Option<K>;
+    /// Convenience method to map a slice of public keys to IDs.
+    fn map_keys_to_ids(&self, keys: &[K]) -> Vec<Option<Id>> {
+        keys.iter().map(|key| self.map_key_to_id(key)).collect()
+    }
+    /// Convenience method to map a slice of IDs to public keys.
+    fn map_ids_to_keys(&self, ids: &[Id]) -> Vec<Option<K>> {
+        ids.iter().map(|id| self.map_id_to_public(id)).collect()
+    }
+}
+
 /// A generic type that can be converted to a hexadecimal string.
 ///
 /// Implementors of this trait should automatically take care of the optional `0x` prefix.


### PR DESCRIPTION
- Add generic key mapping trait to primitive types
- Add rule file for CodeRabbit.ai from monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new public trait enabling bidirectional mapping between key identifiers and their corresponding public keys. Supports transformations for individual keys and batch operations on multiple keys simultaneously

* **Chores**
  * Version updated to 1.2.0
  * Added configuration for development code reviews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->