### PR TITLE
docs: add README badges, doc comments, renovate config and workflow updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,10 @@
   "rangeStrategy": "bump",
   "packageRules": [
     { "matchCategories": ["rust"], "enabled": true },
-    { "matchCategories": ["github-actions"], "enabled": true, "pinDigests": true }
+    {
+      "matchCategories": ["github-actions"],
+      "enabled": true,
+      "pinDigests": true
+    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,18 @@
+{
+  "enabled": true,
+  "prCreation": "not-pending",
+  "extends": [
+    "schedule:earlyMondays",
+    "config:recommended",
+    "group:allNonMajor",
+    "group:allDigest",
+    ":disableDependencyDashboard"
+  ],
+  "vulnerabilityAlerts": { "enabled": true },
+  "semanticCommits": "enabled",
+  "rangeStrategy": "bump",
+  "packageRules": [
+    { "matchCategories": ["rust"], "enabled": true },
+    { "matchCategories": ["github-actions"], "enabled": true, "pinDigests": true }
+  ]
+}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -45,6 +45,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   notify:
     name: Notify failure
+    permissions: {}
     needs:
       - build-library
       - publish-dry-run

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,7 +49,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: true
           egress-policy: audit

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted-hoprnet-small
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           disable-sudo: false
           egress-policy: audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ license = "GPL-3.0-only"
 edition = "2024"
 rust-version = "1.93"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [package.metadata.crane]
 name = "hopr-types"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # HOPR Types
 
+[![Crates.io](https://img.shields.io/crates/v/hopr-types)](https://crates.io/crates/hopr-types)
+[![docs.rs](https://img.shields.io/docsrs/hopr-types)](https://docs.rs/hopr-types)
+[![Security](https://github.com/hoprnet/hopr-types/actions/workflows/checks-zizmor.yaml/badge.svg)](https://github.com/hoprnet/hopr-types/actions/workflows/checks-zizmor.yaml)
+[![License](https://img.shields.io/crates/l/hopr-types)](https://github.com/hoprnet/hopr-types/blob/main/LICENSE)
+[![MSRV](https://img.shields.io/crates/msrv/hopr-types)](https://github.com/hoprnet/hopr-types)
+[![Crates.io Downloads](https://img.shields.io/crates/d/hopr-types)](https://crates.io/crates/hopr-types)
 [![codecov](https://codecov.io/gh/hoprnet/hopr-types/branch/main/graph/badge.svg)](https://codecov.io/gh/hoprnet/hopr-types)
 
 A collection of Rust types used within the HOPR network and related projects.
@@ -26,4 +32,4 @@ Use `all-types` to enable all of the above. Features form a dependency chain: `c
 
 ## License
 
-This project is licensed under the [GPL-3.0-only](LICENSE).
+This project is licensed under the [GPL-3.0-only](https://github.com/hoprnet/hopr-types/blob/main/LICENSE).

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -1,9 +1,12 @@
 //! This module contains various on-chain related modules and types.
 
+/// Types representing events emitted by HOPR smart contracts.
 pub mod chain_events;
+/// Error types for chain-related operations.
 pub mod errors;
 #[cfg(feature = "use-bindings")]
 mod parser;
+/// Ethereum transaction payload generators for on-chain actions.
 pub mod payload;
 
 #[cfg(feature = "use-bindings")]

--- a/src/chain/payload/bindings_based.rs
+++ b/src/chain/payload/bindings_based.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use crate::crypto::prelude::*;
 use crate::internal::prelude::*;
 use crate::primitive::prelude::*;
+/// Re-export of the Alloy [`TransactionRequest`] type for constructing on-chain transactions.
 pub use hopr_bindings::exports::alloy::rpc::types::TransactionRequest;
 use hopr_bindings::{
     exports::alloy::{
@@ -158,6 +159,7 @@ pub struct BasicPayloadGenerator {
 }
 
 impl BasicPayloadGenerator {
+    /// Creates a new [`BasicPayloadGenerator`] for the given node address and contract addresses.
     pub fn new(me: Address, contract_addrs: ContractAddresses) -> Self {
         Self { me, contract_addrs }
     }
@@ -389,6 +391,8 @@ pub struct SafePayloadGenerator {
 }
 
 impl SafePayloadGenerator {
+    /// Creates a new [`SafePayloadGenerator`] using the given chain keypair,
+    /// contract addresses, and Safe module address.
     pub fn new(
         chain_keypair: &ChainKeypair,
         contract_addrs: ContractAddresses,

--- a/src/chain/payload/mod.rs
+++ b/src/chain/payload/mod.rs
@@ -1,12 +1,12 @@
 //! Module defining various Ethereum transaction payload generators for the actions.
 //!
-//! This module defines the basic [`PayloadGenerator`] trait that describes how an action
-//! is translated into a [`TransactionRequest`] that can be submitted on-chain.
+//! This module defines the basic `PayloadGenerator` trait that describes how an action
+//! is translated into a `TransactionRequest` that can be submitted on-chain.
 //!
 //! There are two main implementations:
-//! - [`BasicPayloadGenerator`] which implements generation of a direct EIP1559 transaction payload. This is currently
+//! - `BasicPayloadGenerator` which implements generation of a direct EIP1559 transaction payload. This is currently
 //!   not used by a HOPR node.
-//! - [`SafePayloadGenerator`] which implements generation of a payload that embeds the transaction data into the SAFE
+//! - `SafePayloadGenerator` which implements generation of a payload that embeds the transaction data into the SAFE
 //!   transaction. This is currently the main mode of HOPR node operation.
 //!
 //! These are currently based on the `hopr-bindings` crate.

--- a/src/crypto/errors.rs
+++ b/src/crypto/errors.rs
@@ -2,6 +2,7 @@ use crate::primitive::errors::GeneralError;
 use k256::elliptic_curve;
 use thiserror::Error;
 
+/// Enumeration of all cryptography-related errors in this crate.
 #[derive(Error, Debug, PartialEq)]
 pub enum CryptoError {
     #[error("cryptographic parameter '{name}' must be {expected} bytes long")]
@@ -13,7 +14,7 @@ pub enum CryptoError {
     #[error("secret scalar results in an invalid EC point")]
     InvalidSecretScalar,
 
-    #[error("ec point represents and invalid public key")]
+    #[error("ec point represents an invalid public key")]
     InvalidPublicKey,
 
     #[error("mac or authentication tag did not match")]
@@ -41,4 +42,5 @@ pub enum CryptoError {
     Other(#[from] GeneralError),
 }
 
+/// Convenience type alias for `Result` with [`CryptoError`] as the error type.
 pub type Result<T> = core::result::Result<T, CryptoError>;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,8 +15,8 @@ pub mod primitives;
 pub mod seal;
 /// Separate module for signature algorithms.
 pub mod signing;
-/// Implements basic cryptography-related types based on [primitives], such as [Hash](types::Hash),
-/// [PublicKey](types::PublicKey) and [Signature](types::Signature).
+/// Implements basic cryptography-related types based on [primitives], such as [Hash](types::Hash)
+/// and [PublicKey](types::PublicKey).
 pub mod types;
 /// Contains small utility functions used in the other crypto modules
 pub mod utils;

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -10,10 +10,13 @@ use crate::crypto::{
 /// AES with 128-bit key in counter-mode (with big-endian counter).
 pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
-// Re-exports of used cryptographic primitives
+/// Blake3 hash function, re-exported from the [`blake3`] crate.
 pub use blake3::{Hasher as Blake3, OutputReader as Blake3Output, hash as blake3_hash};
+/// ChaCha20 stream cipher, re-exported from the [`chacha20`] crate.
 pub use chacha20::ChaCha20;
+/// Poly1305 one-time authenticator, re-exported from the [`poly1305`] crate.
 pub use poly1305::Poly1305;
+/// Keccak-256 and SHA3-256 hash functions, re-exported from the [`sha3`] crate.
 pub use sha3::{Keccak256, Sha3_256};
 
 /// Represents a 256-bit secret key of fixed length.

--- a/src/crypto/seal.rs
+++ b/src/crypto/seal.rs
@@ -2,7 +2,7 @@ use libp2p_identity::PeerId;
 
 use crate::crypto::keypairs::OffchainKeypair;
 
-/// **CURRENTLY NOT IMPLEMENTED**, see https://github.com/hoprnet/hoprnet/issues/7172
+/// **CURRENTLY NOT IMPLEMENTED**, see <https://github.com/hoprnet/hoprnet/issues/7172>
 ///
 /// Performs randomized encryption of the given data so that
 /// only the recipient with the given `peer_id` can [decrypt it](unseal_data).
@@ -11,7 +11,7 @@ pub fn seal_data(_data: &[u8], _peer_id: PeerId) -> crate::crypto::errors::Resul
     Err(crate::crypto::errors::CryptoError::SealingError)
 }
 
-/// **CURRENTLY NOT IMPLEMENTED**, see https://github.com/hoprnet/hoprnet/issues/7172
+/// **CURRENTLY NOT IMPLEMENTED**, see <https://github.com/hoprnet/hoprnet/issues/7172>
 ///
 /// Decrypts data previously encrypted with [`seal_data`].
 ///

--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -122,7 +122,8 @@ impl EcdsaEngine for NativeEcdsaSigningEngine {
 }
 
 /// Represents an ECDSA signature based on the secp256k1 curve with a recoverable public key.
-/// The signature uses Keccak256 as the hash function.
+/// When signing messages, Keccak256 is used as the hash function;
+/// `sign_hash` operates on an arbitrary pre-computed hash.
 ///
 /// This signature encodes the 2-bit recovery information into the
 /// uppermost bits from MSB of the `S` value, which are never used by this ECDSA

--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -122,7 +122,7 @@ impl EcdsaEngine for NativeEcdsaSigningEngine {
 }
 
 /// Represents an ECDSA signature based on the secp256k1 curve with a recoverable public key.
-/// The signature uses [Keccak256](Hash) as the hash function.
+/// The signature uses Keccak256 as the hash function.
 ///
 /// This signature encodes the 2-bit recovery information into the
 /// uppermost bits from MSB of the `S` value, which are never used by this ECDSA
@@ -237,9 +237,13 @@ impl<E> BytesRepresentable for ChainSignature<E> {
     const SIZE: usize = ECDSA_SIGNATURE_SIZE;
 }
 
+/// Default ECDSA signature type using the native secp256k1 signing engine.
 #[cfg(not(feature = "rust-ecdsa"))]
 pub type Signature = ChainSignature<NativeEcdsaSigningEngine>;
 
+/// ECDSA signature type using the pure-Rust k256 signing engine.
+///
+/// Active when the `rust-ecdsa` feature is enabled.
 #[cfg(feature = "rust-ecdsa")]
 pub type Signature = ChainSignature<K256EcdsaSigningEngine>;
 

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -230,6 +230,10 @@ impl Default for HalfKeyChallenge {
 }
 
 impl HalfKeyChallenge {
+    /// Creates a new [`HalfKeyChallenge`] from the given byte slice.
+    ///
+    /// # Panics
+    /// Panics if `half_key_challenge` length is not equal to [`HalfKeyChallenge::SIZE`].
     pub fn new(half_key_challenge: &[u8]) -> Self {
         let mut ret = Self::default();
         ret.0.copy_from_slice(half_key_challenge);
@@ -598,6 +602,7 @@ impl PublicKey {
     pub const SIZE_COMPRESSED: usize = 33;
     /// Size of the uncompressed public key in bytes
     pub const SIZE_UNCOMPRESSED: usize = 65;
+    /// Size of the uncompressed public key without the `0x04` SEC1 prefix byte (64 bytes).
     pub const SIZE_UNCOMPRESSED_PLAIN: usize = 64;
 
     /// Computes the public key from the given `private_key`.

--- a/src/crypto_random/mod.rs
+++ b/src/crypto_random/mod.rs
@@ -5,6 +5,7 @@
 //! exclusively rely on randomness functions only from this crate.
 
 use generic_array::{ArrayLength, GenericArray};
+/// Re-export of the [`Rng`] trait for generic random value generation.
 pub use rand::Rng;
 use rand::{CryptoRng, RngExt};
 

--- a/src/internal/account.rs
+++ b/src/internal/account.rs
@@ -59,6 +59,8 @@ impl AccountEntry {
         }
     }
 
+    /// Returns the multiaddresses of this account entry, or an empty slice
+    /// if the node is not announced.
     pub fn get_multiaddrs(&self) -> &[Multiaddr] {
         match &self.entry_type {
             AccountType::NotAnnounced => &[],

--- a/src/internal/channels.rs
+++ b/src/internal/channels.rs
@@ -94,7 +94,7 @@ pub enum ChannelDirection {
     Outgoing = 1,
 }
 
-/// Alias for the [`Hash`](struct@Hash) representing a channel ID.
+/// Alias for the [`Hash`](tyalias@Hash) representing a channel ID.
 pub type ChannelId = Hash;
 
 /// An immutable pair of addresses representing parties of a channel.

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -70,4 +70,5 @@ pub enum PathError {
     OtherError(#[from] GeneralError),
 }
 
+/// Convenience type alias for `Result` with [`CoreTypesError`] as the error type.
 pub type Result<T> = core::result::Result<T, CoreTypesError>;

--- a/src/internal/path.rs
+++ b/src/internal/path.rs
@@ -63,6 +63,7 @@ impl<T: Into<PathAddress> + Copy + PartialEq + Eq> Path<T> for Vec<T> {
     }
 }
 
+/// A path of [`Address`]es representing intermediate hops in a payment channel route.
 pub type ChannelPath = Vec<Address>;
 
 /// A [`NonEmptyPath`] that can be used to route packets using [`OffchainPublicKey`].

--- a/src/internal/path.rs
+++ b/src/internal/path.rs
@@ -155,7 +155,7 @@ impl ChainPath {
         Self(vec![destination])
     }
 
-    /// Converts this chain path into the [`ChainPath`] by removing the destination.
+    /// Converts this chain path into a [`ChannelPath`] by removing the destination.
     pub fn into_channel_path(mut self) -> ChannelPath {
         self.0.pop();
         self.0

--- a/src/internal/routing.rs
+++ b/src/internal/routing.rs
@@ -196,12 +196,14 @@ impl std::fmt::Debug for HoprSenderId {
 }
 
 impl HoprSenderId {
+    /// Creates a new [`HoprSenderId`] with the given pseudonym and a random SURB ID.
     pub fn new(pseudonym: &HoprPseudonym) -> Self {
         let mut ret: [u8; Self::SIZE] = crate::crypto_random::random_bytes();
         ret[..HoprPseudonym::SIZE].copy_from_slice(pseudonym.as_ref());
         Self(ret)
     }
 
+    /// Creates a [`HoprSenderId`] from an explicit pseudonym and SURB ID.
     pub fn from_pseudonym_and_id(pseudonym: &HoprPseudonym, id: HoprSurbId) -> Self {
         let mut ret = [0u8; Self::SIZE];
         ret[..HoprPseudonym::SIZE].copy_from_slice(pseudonym.as_ref());
@@ -209,10 +211,12 @@ impl HoprSenderId {
         Self(ret)
     }
 
+    /// Returns the [`HoprPseudonym`] part of this sender ID.
     pub fn pseudonym(&self) -> HoprPseudonym {
         HoprPseudonym::try_from(&self.0[..HoprPseudonym::SIZE]).expect("must have valid pseudonym")
     }
 
+    /// Returns the [`HoprSurbId`] part of this sender ID.
     pub fn surb_id(&self) -> HoprSurbId {
         self.0[HoprPseudonym::SIZE..HoprPseudonym::SIZE + SURB_ID_SIZE]
             .try_into()

--- a/src/internal/tickets.rs
+++ b/src/internal/tickets.rs
@@ -44,8 +44,12 @@ pub struct WinningProbability(
 impl WinningProbability {
     /// 100% winning probability
     pub const ALWAYS: Self = Self([0xff; ENCODED_WIN_PROB_LENGTH]);
-    /// Tolerance threshold for floating-point probability comparisons.
-    /// Differences smaller than this are treated as equal to 0% or 100%.
+    /// Tolerance threshold for approximate floating-point probability comparisons.
+    ///
+    /// Two probabilities whose absolute difference is below this value are treated
+    /// as equal by [`Self::approx_cmp`]/[`Self::approx_eq`], and values within
+    /// this tolerance of `0.0` or `1.0` are snapped to [`Self::NEVER`] / [`Self::ALWAYS`]
+    /// by [`Self::try_from_f64`].
     pub const EPSILON: f64 = 0.00000001;
     /// 0% winning probability.
     pub const NEVER: Self = Self([0u8; ENCODED_WIN_PROB_LENGTH]);

--- a/src/internal/tickets.rs
+++ b/src/internal/tickets.rs
@@ -44,8 +44,8 @@ pub struct WinningProbability(
 impl WinningProbability {
     /// 100% winning probability
     pub const ALWAYS: Self = Self([0xff; ENCODED_WIN_PROB_LENGTH]);
-    /// The smallest representable non-zero probability difference.
-    /// Values below this threshold are treated as zero probability.
+    /// Tolerance threshold for floating-point probability comparisons.
+    /// Differences smaller than this are treated as equal to 0% or 100%.
     pub const EPSILON: f64 = 0.00000001;
     /// 0% winning probability.
     pub const NEVER: Self = Self([0u8; ENCODED_WIN_PROB_LENGTH]);

--- a/src/internal/tickets.rs
+++ b/src/internal/tickets.rs
@@ -24,7 +24,6 @@ const ENCODED_WIN_PROB_LENGTH: usize = 7;
 /// Define the selector for the redeemTicketCall to avoid importing
 /// the entire hopr-bindings crate for one single constant.
 /// This value should be updated with the function interface changes.
-// pub const REDEEM_CALL_SELECTOR: [u8; 4] = [252, 183, 121, 111];
 pub const REDEEM_CALL_SELECTOR: [u8; 4] = [101, 227, 250, 114];
 
 /// Winning probability encoded in 7-byte representation
@@ -45,8 +44,8 @@ pub struct WinningProbability(
 impl WinningProbability {
     /// 100% winning probability
     pub const ALWAYS: Self = Self([0xff; ENCODED_WIN_PROB_LENGTH]);
-    // This value can no longer be represented with the winning probability encoding
-    // and is equal to 0
+    /// The smallest representable non-zero probability difference.
+    /// Values below this threshold are treated as zero probability.
     pub const EPSILON: f64 = 0.00000001;
     /// 0% winning probability.
     pub const NEVER: Self = Self([0u8; ENCODED_WIN_PROB_LENGTH]);
@@ -803,7 +802,7 @@ const ON_CHAIN_TICKET_SIZE: usize = 60 + EthereumChallenge::SIZE + Signature::SI
 impl BytesEncodable<TICKET_SIZE> for Ticket {}
 
 /// Holds a ticket that has been already verified.
-/// This structure guarantees that [`Ticket::get_hash()`] of [`VerifiedTicket::verified_ticket()`]
+/// This structure guarantees that `Ticket::get_hash()` of [`VerifiedTicket::verified_ticket()`]
 /// is always equal to [`VerifiedTicket::verified_hash`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -870,7 +869,7 @@ impl VerifiedTicket {
     }
 
     /// Fixed ticket hash that is guaranteed to be equal to
-    /// [`Ticket::get_hash`] of [`VerifiedTicket::verified_ticket`].
+    /// `Ticket::get_hash` of [`VerifiedTicket::verified_ticket`].
     #[inline]
     pub fn verified_hash(&self) -> &Hash {
         &self.hash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-//! Contains all HOPR-specific or related Rust types.
-//!
-//! The individual types are feature-gated.
+#![doc = include_str!("../README.md")]
 
 /// Basic public types used in the HOPR protocol.
 #[cfg(feature = "primitive")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! Contains all HOPR-specific or related Rust types.
 #![doc = include_str!("../README.md")]
 
 /// Basic public types used in the HOPR protocol.

--- a/src/primitive/balance.rs
+++ b/src/primitive/balance.rs
@@ -355,10 +355,13 @@ impl<C: Currency> UnitaryFloatOps for Balance<C> {
     }
 }
 
+/// Balance denominated in wxHOPR (wrapped xHOPR) tokens.
 pub type HoprBalance = Balance<WxHOPR>;
 
+/// Balance denominated in xHOPR tokens.
 pub type XHoprBalance = Balance<XHOPR>;
 
+/// Balance denominated in xDai (native gas token).
 pub type XDaiBalance = Balance<XDai>;
 
 #[cfg(test)]

--- a/src/primitive/errors.rs
+++ b/src/primitive/errors.rs
@@ -17,4 +17,5 @@ pub enum GeneralError {
     NonSpecificError(String),
 }
 
+/// Convenience type alias for `Result` with [`GeneralError`] as the error type.
 pub type Result<T> = core::result::Result<T, GeneralError>;

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -41,6 +41,7 @@ pub fn to_hex_shortened<const M: usize>(data: &impl AsRef<[u8]>) -> String {
     }
 }
 
+/// Re-exports of the most commonly used primitive types and traits.
 pub mod prelude {
     pub use chrono::{DateTime, Utc};
 

--- a/src/primitive/primitives.rs
+++ b/src/primitive/primitives.rs
@@ -17,7 +17,7 @@ use crate::primitive::{
     traits::{IntoEndian, ToHex, UnitaryFloatOps},
 };
 
-/// 256-bit unsigned integer type, re-exported from [`primitive_types`].
+/// 256-bit unsigned integer type alias for [`primitive_types::U256`].
 pub type U256 = primitive_types::U256;
 
 /// Represents an Ethereum address

--- a/src/primitive/primitives.rs
+++ b/src/primitive/primitives.rs
@@ -17,6 +17,7 @@ use crate::primitive::{
     traits::{IntoEndian, ToHex, UnitaryFloatOps},
 };
 
+/// 256-bit unsigned integer type, re-exported from [`primitive_types`].
 pub type U256 = primitive_types::U256;
 
 /// Represents an Ethereum address
@@ -38,6 +39,10 @@ impl Display for Address {
 }
 
 impl Address {
+    /// Creates a new [`Address`] from the given byte slice.
+    ///
+    /// # Panics
+    /// Panics if `bytes` length is not equal to [`Address::SIZE`] (20 bytes).
     pub fn new(bytes: &[u8]) -> Self {
         assert_eq!(bytes.len(), Self::SIZE, "invalid length");
         let mut ret = Self::default();
@@ -45,6 +50,8 @@ impl Address {
         ret
     }
 
+    /// Converts this 20-byte address into a 32-byte ABI-encoded representation
+    /// by left-padding with 12 zero bytes.
     pub fn to_bytes32(&self) -> Box<[u8]> {
         let mut ret = Vec::with_capacity(12 + Self::SIZE);
         ret.extend_from_slice(&[0u8; 12]);


### PR DESCRIPTION
## Summary

- Add README badges (Crates.io, docs.rs, Security, License, MSRV, Downloads, codecov) matching hopr-api conventions
- Implement #23: add `#![doc = include_str!("../README.md")]` for crate-level docs, add `[package.metadata.docs.rs] all-features = true`, add `///` doc comments to all undocumented public API items across all modules
- Add `.github/renovate.json` from hopr-api for automated dependency management
- Bump `harden-runner` v2.16.0 to v2.19.0 in `pr.yaml` and `update-flake-lock.yaml`
- Add `permissions: {}` to merge notify job (least privilege)
- Fix typo in `crypto/errors.rs` ("and invalid" -> "an invalid")
- Remove dead commented-out code in `tickets.rs`
- Fix all pre-existing rustdoc warnings (bare URLs, broken intra-doc links)

Closes #23