### PR TITLE
ci: disable benchmark jobs for now

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -35,8 +35,9 @@ jobs:
       source_branch: ${{ github.ref_name }}
       runner: depot-ubuntu-24.04-4
       bencher_project: ${{ github.event.repository.name }}
-      should_build: true
-      should_run: true
+      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      should_build: false
+      should_run: false
       build_command: "nix build -L .#bench-build"
       run_command: "nix run .#bench-run"
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -135,8 +135,9 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref }}
       runner: depot-ubuntu-24.04-4
       bencher_project: ${{ github.event.repository.name }}
-      should_build: true
-      should_run: true
+      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      should_build: false
+      should_run: false
       build_command: "nix build -L .#bench-build"
       run_command: "nix run .#bench-run"
     secrets:


### PR DESCRIPTION
## Summary

- Flip `should_build` and `should_run` to `false` in both benchmark job callers (`pr.yaml`, `branches.yaml`).
- The reusable workflow's own `if: inputs.should_build` / `if: inputs.should_run` gates make both subjobs skip with no runner cost and no Bencher.dev uploads.
- All bench code (`benches/`, `[[bench]]` entries, criterion dev-deps, nix `bench-build`/`bench-run` targets) is untouched — `cargo bench` and `nix run .#bench-run` still work locally.

**Re-enable:** flip both booleans back to `true` and remove the comment line.

Sibling PR: hoprnet/hoprnet#8183