### PR TITLE
feat(ci): migrate workflows to Workload Identity Provider auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,9 +37,10 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@4e3c270b51ed1817bc0b0f6996dfc8a7b0e757c1 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v2
         with:
           source_branch: ${{ github.ref_name }}
           release_type: ${{ inputs.release_type }}
@@ -48,5 +49,4 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: HOPRd
           zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Pins all `hoprnet/hopr-workflows` action/workflow refs to new OIDC-enabled SHAs
- Removes legacy `gcp_service_account`, `google_credentials`, and `GH_RUNNER_TOKEN` PAT from workflow inputs
- Adds `id-token: write` permission to every consumer job for OIDC token minting
- Adds `github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}` to all `release-version` invocations

Part of the org-wide WIF migration following the GitHub security incident. Reference: hoprnet/blokli#377