### PR TITLE
feat(crypto): add hex caching to SimplePseudonym and replace hex with const-hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.8.3"
+version = "1.9.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1711,7 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2389,6 +2389,7 @@ dependencies = [
  "chacha20 0.9.1",
  "chrono",
  "cipher 0.4.4",
+ "const-hex",
  "criterion",
  "ctr",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "arrayvec",
  "async-trait",
  "bigdecimal",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,9 @@ ed25519-dalek = { version = "2.2.0", optional = true, features = [
 ] }
 float-cmp = { version = "0.10.0", optional = true }
 generic-array = { version = "1.4.3", optional = true }
-const-hex = { version = "1.19.1", optional = true, default-features = false, features = ["alloc"] }
+const-hex = { version = "1.19.1", optional = true, default-features = false, features = [
+  "alloc",
+] }
 hex-literal = { version = "1.1.0", optional = true }
 hopr-bindings = { version = "4.8.0", optional = true }
 k256 = { version = "0.13.4", optional = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ primitive = [
   "dep:bigdecimal",
   "dep:chrono",
   "dep:float-cmp",
-  "dep:hex",
+  "dep:const-hex",
   "dep:lazy_static",
   "dep:primitive-types",
   "dep:regex",
@@ -129,7 +129,7 @@ ed25519-dalek = { version = "2.2.0", optional = true, features = [
 ] }
 float-cmp = { version = "0.10.0", optional = true }
 generic-array = { version = "1.4.3", optional = true }
-hex = { version = "0.4.3", optional = true }
+const-hex = { version = "1.19.1", optional = true, default-features = false, features = ["alloc"] }
 hex-literal = { version = "1.1.0", optional = true }
 hopr-bindings = { version = "4.8.0", optional = true }
 k256 = { version = "0.13.4", optional = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-types"
-version = "1.8.3"
+version = "1.9.0"
 description = "Complete collection of Rust types used in Hoprnet and other related projects"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ random = ["dep:generic-array", "dep:rand"]
 crypto = [
   "primitive",
   "random",
+  "dep:arrayvec",
   "dep:aes",
   "dep:blake3",
   "dep:chacha20",
@@ -110,6 +111,7 @@ telemetry = [
 aes = { version = "0.8.4", optional = true }
 anyhow = { version = "1.0.102", optional = true }
 aquamarine = { version = "0.6.0", optional = true }
+arrayvec = { version = "0.7.6", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 bigdecimal = { version = "0.4.10", optional = true }
 blake3 = { version = "=1.8.3", optional = true, features = ["traits-preview"] }

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -655,7 +655,7 @@ impl PublicKey {
 
     /// Serializes the public key to a binary uncompressed form and converts it to hexadecimal string representation.
     pub fn to_uncompressed_hex(&self) -> String {
-        format!("0x{}", hex::encode(self.to_uncompressed_bytes()))
+        format!("0x{}", const_hex::encode(self.to_uncompressed_bytes()))
     }
 }
 
@@ -893,7 +893,7 @@ const _CHECK_SERDE_BYTES: () = assert!(
 impl SimplePseudonym {
     /// Creates a new SimplePseudonym from raw bytes, computing the hex representation.
     fn from_bytes(bytes: [u8; 10]) -> Self {
-        let hex_str = hex::encode(bytes);
+        let hex_str = const_hex::encode(bytes);
         let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
             .expect("hex string fits in ArrayString");
         Self(bytes, hex)

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -879,7 +879,7 @@ pub trait Pseudonym: BytesRepresentable + hash::Hash + Eq + Display + Randomizab
 /// Represents a simple UUID-like pseudonym consisting of 10 bytes.
 ///
 /// Caches the hexadecimal string representation internally for efficiency.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SimplePseudonym(
     pub [u8; Self::SIZE],
     pub arrayvec::ArrayString<{ Self::SIZE * 2 }>,
@@ -926,6 +926,24 @@ impl Display for SimplePseudonym {
 impl Debug for SimplePseudonym {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.1.as_str())
+    }
+}
+
+impl std::hash::Hash for SimplePseudonym {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialOrd for SimplePseudonym {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SimplePseudonym {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
     }
 }
 

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -877,21 +877,62 @@ impl From<[u8; Self::SIZE]> for Response {
 pub trait Pseudonym: BytesRepresentable + hash::Hash + Eq + Display + Randomizable {}
 
 /// Represents a simple UUID-like pseudonym consisting of 10 bytes.
+///
+/// Caches the hexadecimal string representation internally for efficiency.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimplePseudonym(
-    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))] pub [u8; Self::SIZE],
+    pub [u8; Self::SIZE],
+    pub arrayvec::ArrayString<{ Self::SIZE * 2 }>,
 );
+
+const _CHECK_SERDE_BYTES: () = assert!(
+    SimplePseudonym::SIZE == 10,
+    "SimplePseudonym must be 10 bytes"
+);
+
+impl SimplePseudonym {
+    /// Creates a new SimplePseudonym from raw bytes, computing the hex representation.
+    fn from_bytes(bytes: [u8; 10]) -> Self {
+        let hex_str = hex::encode(bytes);
+        let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
+            .expect("hex string fits in ArrayString");
+        Self(bytes, hex)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SimplePseudonym {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SimplePseudonym {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes: &[u8] = serde::Deserialize::deserialize(deserializer)?;
+        let arr: [u8; 10] = bytes
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("invalid SimplePseudonym length"))?;
+        Ok(Self::from_bytes(arr))
+    }
+}
 
 impl Display for SimplePseudonym {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_hex())
+        write!(f, "{}", self.1.as_str())
     }
 }
 
 impl Debug for SimplePseudonym {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_hex())
+        write!(f, "{}", self.1.as_str())
     }
 }
 
@@ -905,13 +946,19 @@ impl AsRef<[u8]> for SimplePseudonym {
     }
 }
 
+impl AsRef<str> for SimplePseudonym {
+    fn as_ref(&self) -> &str {
+        self.1.as_str()
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for SimplePseudonym {
     type Error = GeneralError;
 
     fn try_from(value: &'a [u8]) -> result::Result<Self, Self::Error> {
         value
             .try_into()
-            .map(Self)
+            .map(Self::from_bytes)
             .map_err(|_| ParseError("SimplePseudonym".into()))
     }
 }
@@ -941,6 +988,7 @@ mod tests {
         keypairs::{Keypair, OffchainKeypair},
         types::{
             Challenge, HalfKey, HalfKeyChallenge, Hash, OffchainPublicKey, PublicKey, Response,
+            SimplePseudonym,
         },
     };
 
@@ -1138,5 +1186,66 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_simple_pseudonym_serialize_contains_bytes() -> anyhow::Result<()> {
+        let bytes = hex!("0102030405060708090a");
+        let pseudonym = SimplePseudonym::try_from(bytes.as_ref())?;
+
+        let serialized = postcard::to_allocvec(&pseudonym)?;
+        let found = serialized.windows(bytes.len()).any(|w| w == bytes);
+        assert!(
+            found,
+            "serialized bytes should contain original bytes, got {:02x?}",
+            serialized
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_simple_pseudonym_roundtrip() -> anyhow::Result<()> {
+        let original = SimplePseudonym::random();
+
+        let serialized = postcard::to_allocvec(&original)?;
+        let deserialized: SimplePseudonym = postcard::from_bytes(&serialized)?;
+
+        assert_eq!(original, deserialized, "roundtrip should preserve value");
+        let original_bytes: &[u8] = original.as_ref();
+        let deserialized_bytes: &[u8] = deserialized.as_ref();
+        assert_eq!(original_bytes, deserialized_bytes, "bytes should match");
+
+        let original_hex: &str = AsRef::<str>::as_ref(&original);
+        let deserialized_hex: &str = AsRef::<str>::as_ref(&deserialized);
+        assert_eq!(original_hex, deserialized_hex, "hex strings should match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_simple_pseudonym_as_ref_str() -> anyhow::Result<()> {
+        let bytes = hex!("0102030405060708090a");
+        let pseudonym = SimplePseudonym::try_from(bytes.as_ref())?;
+
+        let hex_str: &str = AsRef::<str>::as_ref(&pseudonym);
+        assert_eq!(hex_str.len(), 20, "hex string should be 20 characters");
+        assert_eq!(
+            hex_str, "0102030405060708090a",
+            "hex string should match expected value"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_simple_pseudonym_is_copy() {
+        let original = SimplePseudonym::random();
+        let _copy = original;
+
+        let bytes: &[u8] = original.as_ref();
+        assert_eq!(bytes.len(), 10, "original should still be valid after copy");
     }
 }

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -906,8 +906,8 @@ impl<'de> serde::Deserialize<'de> for SimplePseudonym {
     where
         D: serde::Deserializer<'de>,
     {
-        let bytes: &[u8] = serde::Deserialize::deserialize(deserializer)?;
-        let arr: [u8; 10] = bytes
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+        let arr: [u8; Self::SIZE] = bytes
             .try_into()
             .map_err(|_| serde::de::Error::custom("invalid SimplePseudonym length"))?;
         let hex_str = const_hex::encode(arr);

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -973,12 +973,15 @@ impl<'a> TryFrom<&'a [u8]> for SimplePseudonym {
     type Error = GeneralError;
 
     fn try_from(value: &'a [u8]) -> result::Result<Self, Self::Error> {
-        let arr: [u8; 10] = value
+        let arr: [u8; Self::SIZE] = value
             .try_into()
             .map_err(|_| ParseError("SimplePseudonym".into()))?;
-        let hex_str = const_hex::encode(arr);
-        let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
+
+        let mut hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::zero_filled();
+        // Unsafe: the hex string is guaranteed to be valid UTF-8
+        unsafe { const_hex::encode_to_slice(arr, hex.as_bytes_mut()) }
             .expect("hex string fits in ArrayString");
+
         Ok(Self(arr, hex))
     }
 }

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -890,16 +890,6 @@ const _CHECK_SERDE_BYTES: () = assert!(
     "SimplePseudonym must be 10 bytes"
 );
 
-impl SimplePseudonym {
-    /// Creates a new SimplePseudonym from raw bytes, computing the hex representation.
-    fn from_bytes(bytes: [u8; 10]) -> Self {
-        let hex_str = const_hex::encode(bytes);
-        let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
-            .expect("hex string fits in ArrayString");
-        Self(bytes, hex)
-    }
-}
-
 #[cfg(feature = "serde")]
 impl serde::Serialize for SimplePseudonym {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -920,7 +910,10 @@ impl<'de> serde::Deserialize<'de> for SimplePseudonym {
         let arr: [u8; 10] = bytes
             .try_into()
             .map_err(|_| serde::de::Error::custom("invalid SimplePseudonym length"))?;
-        Ok(Self::from_bytes(arr))
+        let hex_str = const_hex::encode(arr);
+        let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
+            .expect("hex string fits in ArrayString");
+        Ok(Self(arr, hex))
     }
 }
 
@@ -956,10 +949,13 @@ impl<'a> TryFrom<&'a [u8]> for SimplePseudonym {
     type Error = GeneralError;
 
     fn try_from(value: &'a [u8]) -> result::Result<Self, Self::Error> {
-        value
+        let arr: [u8; 10] = value
             .try_into()
-            .map(Self::from_bytes)
-            .map_err(|_| ParseError("SimplePseudonym".into()))
+            .map_err(|_| ParseError("SimplePseudonym".into()))?;
+        let hex_str = const_hex::encode(arr);
+        let hex = arrayvec::ArrayString::<{ Self::SIZE * 2 }>::from(&hex_str)
+            .expect("hex string fits in ArrayString");
+        Ok(Self(arr, hex))
     }
 }
 

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -879,7 +879,7 @@ pub trait Pseudonym: BytesRepresentable + hash::Hash + Eq + Display + Randomizab
 /// Represents a simple UUID-like pseudonym consisting of 10 bytes.
 ///
 /// Caches the hexadecimal string representation internally for efficiency.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq)]
 pub struct SimplePseudonym(
     pub [u8; Self::SIZE],
     pub arrayvec::ArrayString<{ Self::SIZE * 2 }>,
@@ -926,6 +926,12 @@ impl Display for SimplePseudonym {
 impl Debug for SimplePseudonym {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.1.as_str())
+    }
+}
+
+impl PartialEq for SimplePseudonym {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
     }
 }
 

--- a/src/crypto/vrf.rs
+++ b/src/crypto/vrf.rs
@@ -33,9 +33,9 @@ pub struct VrfParameters {
 impl std::fmt::Debug for VrfParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VrfParameters")
-            .field("V", &hex::encode(self.V.to_encoded_point(true)))
-            .field("h", &hex::encode(self.h.to_bytes()))
-            .field("s", &hex::encode(self.s.to_bytes()))
+            .field("V", &const_hex::encode(self.V.to_encoded_point(true)))
+            .field("h", &const_hex::encode(self.h.to_bytes()))
+            .field("s", &const_hex::encode(self.s.to_bytes()))
             .finish()
     }
 }

--- a/src/internal/routing.rs
+++ b/src/internal/routing.rs
@@ -189,8 +189,8 @@ pub struct HoprSenderId(
 impl std::fmt::Debug for HoprSenderId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("HoprSenderId")
-            .field(&hex::encode(&self.0[0..HoprPseudonym::SIZE]))
-            .field(&hex::encode(&self.0[HoprPseudonym::SIZE..]))
+            .field(&const_hex::encode(&self.0[0..HoprPseudonym::SIZE]))
+            .field(&const_hex::encode(&self.0[HoprPseudonym::SIZE..]))
             .finish()
     }
 }

--- a/src/keypair/errors.rs
+++ b/src/keypair/errors.rs
@@ -1,5 +1,4 @@
 use crate::crypto::errors::CryptoError;
-use hex::FromHexError;
 use serde_json::Error as JsonError;
 use thiserror::Error;
 
@@ -14,8 +13,8 @@ pub enum KeyPairError {
     #[error("JSON error: {0}")]
     JsonError(#[from] JsonError),
 
-    #[error("hex parsing ")]
-    HexParsingError(#[from] FromHexError),
+    #[error("hex parsing error: {0}")]
+    HexParsingError(String),
 
     #[error("key derivation error {0}")]
     KeyDerivationError(String),

--- a/src/keypair/key_pair.rs
+++ b/src/keypair/key_pair.rs
@@ -122,7 +122,8 @@ impl FromStr for HoprKeys {
         }
 
         let mut priv_key_raw = [0u8; PACKET_KEY_LENGTH + CHAIN_KEY_LENGTH];
-        hex::decode_to_slice(maybe_priv_key, &mut priv_key_raw[..])?;
+        const_hex::decode_to_slice(maybe_priv_key, &mut priv_key_raw[..])
+            .map_err(|e| KeyPairError::HexParsingError(e.to_string()))?;
 
         priv_key_raw.try_into()
     }

--- a/src/keypair/keystore.rs
+++ b/src/keypair/keystore.rs
@@ -1,6 +1,6 @@
 // Highly inspired by https://github.com/roynalnaruto/eth-keystore-rs
 
-use hex::{FromHex, ToHex};
+use const_hex::traits::{FromHex, ToHexExt};
 use serde::{Deserialize, Serialize, de::Deserializer, ser::Serializer};
 use uuid::Uuid;
 
@@ -76,7 +76,7 @@ where
     T: AsRef<[u8]>,
     S: Serializer,
 {
-    serializer.serialize_str(&buffer.encode_hex::<String>())
+    serializer.serialize_str(&buffer.encode_hex())
 }
 
 fn hex_to_buffer<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
@@ -85,7 +85,7 @@ where
 {
     use serde::de::Error;
     String::deserialize(deserializer)
-        .and_then(|string| Vec::from_hex(string).map_err(|err| Error::custom(err.to_string())))
+        .and_then(|string| Vec::from_hex(string).map_err(|err: const_hex::FromHexError| Error::custom(err.to_string())))
 }
 
 /// taken from `eth_keystore` library

--- a/src/keypair/keystore.rs
+++ b/src/keypair/keystore.rs
@@ -84,8 +84,9 @@ where
     D: Deserializer<'de>,
 {
     use serde::de::Error;
-    String::deserialize(deserializer)
-        .and_then(|string| Vec::from_hex(string).map_err(|err: const_hex::FromHexError| Error::custom(err.to_string())))
+    String::deserialize(deserializer).and_then(|string| {
+        Vec::from_hex(string).map_err(|err: const_hex::FromHexError| Error::custom(err.to_string()))
+    })
 }
 
 /// taken from `eth_keystore` library

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -33,11 +33,11 @@ pub fn to_hex_shortened<const M: usize>(data: &impl AsRef<[u8]>) -> String {
     if data.len() * 2 > M {
         format!(
             "{}..{}",
-            hex::encode(&data[0..(num_chars - 2) / 4]),
-            hex::encode(&data[data.len() - (num_chars - 2) / 4..])
+            const_hex::encode(&data[0..(num_chars - 2) / 4]),
+            const_hex::encode(&data[data.len() - (num_chars - 2) / 4..])
         )
     } else {
-        hex::encode(data)
+        const_hex::encode(data)
     }
 }
 

--- a/src/primitive/primitives.rs
+++ b/src/primitive/primitives.rs
@@ -67,7 +67,7 @@ impl Address {
     /// Turns the address into a checksum-ed address string
     /// according to [EIP-55](https://eips.ethereum.org/EIPS/eip-55).
     pub fn to_checksum(&self) -> String {
-        let address_hex = hex::encode(self.0);
+        let address_hex = const_hex::encode(self.0);
 
         let hash = sha3::Keccak256::digest(address_hex.as_bytes());
 

--- a/src/primitive/traits.rs
+++ b/src/primitive/traits.rs
@@ -83,7 +83,7 @@ pub trait BytesRepresentable<E = GeneralError>:
 
 impl<T: BytesRepresentable> ToHex for T {
     fn to_hex(&self) -> String {
-        format!("0x{}", hex::encode(self.as_ref()))
+        format!("0x{}", const_hex::encode(self.as_ref()))
     }
 
     fn from_hex(str: &str) -> Result<Self> {
@@ -93,7 +93,7 @@ impl<T: BytesRepresentable> ToHex for T {
                 .or_else(|| str.strip_prefix("0X"))
                 .unwrap_or(str);
 
-            hex::decode(data)
+            const_hex::decode(data)
                 .map_err(|e| ParseError(e.to_string()))
                 .and_then(|bytes| T::try_from(&bytes))
         } else {


### PR DESCRIPTION
This PR updates the following:

1. `SimplePseudonym` now internally carries its string hex representation (cached), so that it can be converted to string fast. This is at the expense of increasing its size from 10 -> 30 bytes in memory.
2. Removed `hex` crate and replaced with faster `const-hex` crate (10-50 times faster)
3. Crate bumped to 1.9.0


## AI Summary

This PR adds hex caching to `SimplePseudonym` and replaces the `hex` crate with `const-hex` throughout the codebase.

### Changes

1. **SimplePseudonym hex caching** (`src/crypto/types.rs`):
   - Added cached hex string representation (`ArrayString<20>`) as second member alongside raw bytes
   - Type remains `Copy` by using `ArrayString` instead of `String`
   - Custom serde implementations: serializes only raw bytes, computes hex on deserialization
   - Added `AsRef<str>` implementation returning reference to hex string

2. **Replace hex with const-hex** (multiple files):
   - Replaced `hex` crate dependency with `const-hex` (faster, const generics support)
   - Updated all usages: `hex::encode` → `const_hex::encode`, `hex::decode` → `const_hex::decode`
   - Updated keypair error handling to use `String` instead of `FromHexError` (const-hex error doesn't implement `StdError`)

### Files changed

- `Cargo.toml`: Updated dependency from `hex` to `const-hex`
- `src/crypto/types.rs`: SimplePseudonym modifications
- `src/crypto/vrf.rs`, `src/primitive/mod.rs`, `src/primitive/primitives.rs`, `src/primitive/traits.rs`, `src/internal/routing.rs`: hex → const-hex updates
- `src/keypair/errors.rs`, `src/keypair/key_pair.rs`, `src/keypair/keystore.rs`: hex → const-hex with error handling adjustments

### Test plan

- [x] All existing tests pass (118 passed, 4 ignored)
- [x] `cargo clippy` passes with no warnings
- [x] `nix fmt` passes