### PR TITLE
fix(ci): pin tests workflow to hopr-workflows#88 for codecov slug fix

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,6 +5,7 @@ on:
       - main
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@993116b2cc11fd7cd1cb376729cd1910f3287f8f # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@389e4773f65fc28aa0f8e45ba59bcb34cfe0ab28 # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,14 +5,13 @@ on:
       - main
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false
 jobs:
   coverage:
     name: Coverage
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@389e4773f65fc28aa0f8e45ba59bcb34cfe0ab28 # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@41ede55de3b903151df56cd8cf697b43528a3ed8 # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,13 +5,14 @@ on:
       - main
 permissions:
   contents: read
-  id-token: write
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false
 jobs:
   coverage:
     name: Coverage
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@41ede55de3b903151df56cd8cf697b43528a3ed8 # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@993116b2cc11fd7cd1cb376729cd1910f3287f8f # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false
@@ -23,7 +23,6 @@ jobs:
       runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   benchmarks:
     name: Benchmarks
     needs: coverage

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,7 +85,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@993116b2cc11fd7cd1cb376729cd1910f3287f8f # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,7 +85,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,7 +85,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@389e4773f65fc28aa0f8e45ba59bcb34cfe0ab28 # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@41ede55de3b903151df56cd8cf697b43528a3ed8 # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,7 +84,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@389e4773f65fc28aa0f8e45ba59bcb34cfe0ab28 # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,6 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -85,6 +84,8 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -84,8 +85,6 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,7 +85,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@41ede55de3b903151df56cd8cf697b43528a3ed8 # hoprnet/hopr-workflows#88
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@993116b2cc11fd7cd1cb376729cd1910f3287f8f # hoprnet/hopr-workflows#88
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -95,7 +95,6 @@ jobs:
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   build-library:
     name: Library ${{ matrix.architecture }}
     strategy:


### PR DESCRIPTION
## Summary

- Migrate Codecov upload from global upload token to GitHub Actions OIDC (`use_oidc: true`)
- Bump `tests.yaml` pin to `workflow-tests-v6` (`798d791de5c5485c3043049781dfd0938539a36a`)
- Remove `CODECOV_TOKEN` secret passthrough — no longer needed with OIDC
- Move `id-token: write` from workflow-level to only the `tests`/`coverage` job to avoid overly broad permissions (Zizmor fix)

Depends on: https://github.com/hoprnet/hopr-workflows/pull/88