### PR TITLE
fix(ci): update branches.yaml to workflow-tests-v6 input names

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -15,12 +15,10 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
-      unit_tests: false
-      integration_tests: false
-      unit_coverage: true
-      unconditional: true
+      enable_unit_tests: false
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   benchmarks:


### PR DESCRIPTION
## Summary

- Fixes \`startup_failure\` on every push to main since #67 was merged
- #67 updated the SHA to \`workflow-tests-v6\` but left old v3 input names in the \`coverage\` job
- Old names rejected by v6: \`unit_tests\`, \`integration_tests\`, \`unit_coverage\`, \`unconditional\`, \`runner\`
- Updated to v6 names: \`enable_unit_tests\`, \`enable_unit_coverage\`, \`runner_unit\`
- Dropped \`integration_tests: false\` (default in v6) and \`unconditional\` (removed in v6)