### PR TITLE
fix(ci): fix workflow input names, zizmor suppression, and SHA pins

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,7 +5,7 @@ on:
       - main
 permissions:
   contents: read
-  id-token: write
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false
@@ -15,12 +15,11 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
-      unit_tests: false
-      integration_tests: false
-      unit_coverage: true
-      unconditional: true
+      enable_unit_tests: false
+      enable_integration_tests: false
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   benchmarks:

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,14 +5,13 @@ on:
       - main
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false
 jobs:
   coverage:
     name: Coverage
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,7 +5,6 @@ on:
       - main
 permissions:
   contents: read
-  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,6 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -84,8 +85,6 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,6 +84,8 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
     permissions:
       contents: read
       id-token: write
@@ -40,7 +40,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@e8d442e87afc739ddff4736e16642744c0c565df # release-version-v5
         with:
           source_branch: ${{ github.ref_name }}
           release_type: ${{ inputs.release_type }}


### PR DESCRIPTION
## Summary

- Fix `branches.yaml` v6 input names (v3 names passed to `workflow-tests-v6`)
- Add `# zizmor: ignore[excessive-permissions]` to `id-token: write` in `branches.yaml` and `pr.yaml` (required for Codecov OIDC; workflow-level placement is forced by the reusable workflow declaring `permissions: {}`)
- Correct `build-library-v3` SHA in `release.yaml` (`6c5db2cd` → `d0cffaf9`, the actual tag commit)
- Update `release-version` pin in `release.yaml` from untagged `fa71078` to `release-version-v5` (`e8d442e`), which includes the `github_app_private_key` input

Supersedes #68.