### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
----
 self-hosted-runner:
   labels:
     - depot-ubuntu-24.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+---
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
                 entry = "${pkgs.pinact}/bin/pinact run --check";
-                files = "\\.ya?ml$";
+                files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;
               };
@@ -172,7 +172,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${pre-commit-check.shellHook}
-              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
             '';
             extraPackages = with pkgs; [
               cargo-release

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,16 @@
                 language = "system";
                 pass_filenames = true;
               };
+              actionlint.enable = true;
+              pinact = {
+                enable = true;
+                name = "pinact";
+                description = "Check GitHub Action refs are SHA-pinned and resolvable";
+                entry = "${pkgs.pinact}/bin/pinact run --check";
+                files = "\\.ya?ml$";
+                language = "system";
+                pass_filenames = false;
+              };
             };
             excludes = sharedExcludes ++ [
               "vendor/"
@@ -162,6 +172,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${pre-commit-check.shellHook}
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
             '';
             extraPackages = with pkgs; [
               cargo-release


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake. Note: depends on WIF migration PR merging first so pinact --check passes on hopr-workflows refs.