### PR TITLE
fix(ci): the release process build-library pin to OIDC-based trusted publishing

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -25,6 +25,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: pr

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,7 +110,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,6 +113,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Updates the pinned SHA for `hoprnet/hopr-workflows/.github/workflows/build-library.yaml` in all three workflow files (`pr.yaml`, `merge.yaml`, `release.yaml`)
- All were behind: `pr.yaml` and `merge.yaml` were on build-library-v2; `release.yaml` was on a post-v3 SHA that predated [hopr-workflows PR#84](https://github.com/hoprnet/hopr-workflows/pull/84) (2026-06-15)
- That migration replaced the static `cargo_registry_token` secret with short-lived OIDC tokens via `rust-lang/crates-io-auth-action` — no secrets or workflow inputs need to change, `id-token: write` is already granted in the caller