### PR TITLE
fix(ci): migrate release publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # build-library OIDC trusted publishing (hoprnet/hopr-workflows#84)
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- The `Close release` workflow was pinned to `build-library-v3` which publishes via a long-lived `cargo_registry_token` secret — a secret that was never provisioned and is the wrong approach.
- Repin to hoprnet/hopr-workflows@`fa71078` (PR #84), which uses `rust-lang/crates-io-auth-action` to mint a short-lived OIDC token via the existing `id-token: write` grant.
- The `secrets:` block (`cachix_auth_token` only) and `id-token: write` permission in `release.yaml` are already correct — no other changes needed.

> **Note:** For the first actual `Close release` dispatch to publish successfully, crates.io Trusted Publishing must be configured for `hopr-types` (workflow: `release.yaml`). Since the crate has never been published before, that step requires a one-time setup on crates.io — outside the scope of this PR.