### PR TITLE
chore: re-export `typenum` in `primitive` module

### DIFF
--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -168,6 +168,12 @@ impl From<SecretValue<typenum::U32>> for [u8; 32] {
     }
 }
 
+impl<L: ArrayLength> std::fmt::Debug for SecretValue<L> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SecretValue").field(&"<redacted>").finish()
+    }
+}
+
 #[cfg(feature = "serde")]
 impl<L: ArrayLength> serde::Serialize for SecretValue<L> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -13,6 +13,9 @@ pub mod primitives;
 /// Defines commonly used traits across the entire code base.
 pub mod traits;
 
+/// Re-exports of the `typenum` crate.
+pub use typenum;
+
 /// Approximately compares two double-precision floats.
 ///
 /// This function first tests if the two values relatively differ by at least `epsilon`.


### PR DESCRIPTION
As in title.

Also adds redacted `Debug` implementation for `SecretValue`.