### PR TITLE
feat: replace generic-array with hybrid-array, bump to major version 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
 ]
 
 [[package]]
@@ -1760,7 +1760,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -1788,7 +1788,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
  "typenum",
 ]
 
@@ -2011,7 +2011,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.9",
+ "generic-array",
 ]
 
 [[package]]
@@ -2182,7 +2182,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.9",
+ "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -2497,18 +2497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
-dependencies = [
- "rustversion",
- "serde_core",
- "typenum",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2755,11 +2743,12 @@ dependencies = [
  "curve25519-dalek 5.0.0",
  "digest 0.11.3",
  "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
  "float-cmp",
- "generic-array 1.4.3",
  "hash2curve",
  "hex-literal",
  "hopr-bindings",
+ "hybrid-array",
  "insta",
  "k256 0.14.0",
  "lazy_static",
@@ -2843,6 +2832,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "serde",
  "subtle",
  "typenum",
  "zeroize",
@@ -4476,7 +4466,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.9",
+ "generic-array",
  "pkcs8 0.10.2",
  "serdect 0.2.0",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.12.0"
+version = "2.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,12 +83,13 @@ serde = [
   "dep:serde_bytes",
   "babyjubjub-ec/serde",
   "chrono/serde",
-  "primitive-types/serde",
   "curve25519-dalek/serde",
+  "elliptic-curve/serde",
   "ed25519-dalek/serde",
   "hybrid-array/serde",
   "k256/serde",
   "libp2p-identity/serde",
+  "primitive-types/serde",
 ]
 fixed-rng = ["random", "dep:lazy_static"]
 rayon = ["internal", "dep:rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-types"
-version = "1.12.0"
+version = "2.0.0"
 description = "Complete collection of Rust types used in Hoprnet and other related projects"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -31,8 +31,9 @@ all-types = [
 primitive = [
   "dep:bigdecimal",
   "dep:chrono",
-  "dep:float-cmp",
   "dep:const-hex",
+  "dep:float-cmp",
+  "dep:hybrid-array",
   "dep:lazy_static",
   "dep:primitive-types",
   "dep:regex",
@@ -55,6 +56,7 @@ crypto = [
   "dep:elliptic-curve",
   "dep:ed25519-dalek",
   "dep:hash2curve",
+  "dep:hybrid-array",
   "dep:k256",
   "dep:libp2p-identity",
   "dep:poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ ed25519-dalek = { version = "3.0.0", optional = true, features = [
   "batch",
 ] }
 float-cmp = { version = "0.10.0", optional = true }
-hybrid-array = { version = "0.4.13", optional = true }
+hybrid-array = { version = "0.4.13", features = ["extra-sizes"], optional = true }
 const-hex = { version = "1.19.1", optional = true, default-features = false, features = [
   "alloc",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,9 @@ ed25519-dalek = { version = "3.0.0", optional = true, features = [
   "batch",
 ] }
 float-cmp = { version = "0.10.0", optional = true }
-hybrid-array = { version = "0.4.13", features = ["extra-sizes"], optional = true }
+hybrid-array = { version = "0.4.13", features = [
+  "extra-sizes",
+], optional = true }
 const-hex = { version = "1.19.1", optional = true, default-features = false, features = [
   "alloc",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-types"
-version = "1.11.2"
+version = "1.12.0"
 description = "Complete collection of Rust types used in Hoprnet and other related projects"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -39,7 +39,7 @@ primitive = [
   "dep:sha3",
   "dep:thiserror",
 ]
-random = ["dep:generic-array", "dep:rand"]
+random = ["dep:hybrid-array", "dep:rand"]
 crypto = [
   "primitive",
   "random",
@@ -52,6 +52,7 @@ crypto = [
   "dep:ctr",
   "dep:curve25519-dalek",
   "dep:digest",
+  "dep:elliptic-curve",
   "dep:ed25519-dalek",
   "dep:hash2curve",
   "dep:k256",
@@ -62,7 +63,7 @@ crypto = [
   "dep:subtle",
   "dep:typenum",
   "dep:zeroize",
-  "generic-array/zeroize",
+  "hybrid-array/zeroize",
 ]
 internal = [
   "crypto",
@@ -85,7 +86,7 @@ serde = [
   "primitive-types/serde",
   "curve25519-dalek/serde",
   "ed25519-dalek/serde",
-  "generic-array/serde",
+  "hybrid-array/serde",
   "k256/serde",
   "libp2p-identity/serde",
 ]
@@ -131,12 +132,17 @@ curve25519-dalek = { version = "5.0.0", optional = true, features = [
   "rand_core",
 ] }
 digest = { version = "0.11.3", optional = true }
+elliptic-curve = { version = "0.14.1", features = [
+  "arithmetic",
+  "ff",
+  "group",
+], optional = true }
 ed25519-dalek = { version = "3.0.0", optional = true, features = [
   "hazmat",
   "batch",
 ] }
 float-cmp = { version = "0.10.0", optional = true }
-generic-array = { version = "1.4.3", optional = true }
+hybrid-array = { version = "0.4.13", optional = true }
 const-hex = { version = "1.19.1", optional = true, default-features = false, features = [
   "alloc",
 ] }
@@ -147,6 +153,7 @@ k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
   "hash2curve",
+  "group-digest",
 ] }
 lazy_static = { version = "1.5.0", optional = true }
 libp2p-identity = { version = "0.2.14", optional = true, features = [

--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -3,7 +3,8 @@ use std::fmt::Debug;
 use crate::crypto_random::{Randomizable, random_bytes};
 use crate::primitive::prelude::*;
 use digest::Digest;
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::Array;
+use hybrid_array::ArraySize;
 #[cfg(feature = "crypto")]
 use sha2::Sha512;
 use subtle::{Choice, ConstantTimeEq};
@@ -21,7 +22,7 @@ use crate::crypto::{
 /// Must be comparable in constant time and zeroized on drop.
 pub trait Keypair: ConstantTimeEq + Sized {
     /// Represents the type of the private (secret) key
-    type SecretLen: ArrayLength;
+    type SecretLen: ArraySize;
 
     /// Represents the type of the public key
     type Public: BytesRepresentable + Clone + PartialEq;
@@ -119,7 +120,7 @@ impl Keypair for ChainKeypair {
 
     fn random() -> Self {
         let (secret, public) = random_group_element();
-        Self(GenericArray::from(secret).into(), public.into())
+        Self(Array(secret).into(), public.into())
     }
 
     fn from_secret(bytes: &[u8]) -> errors::Result<Self> {

--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -181,7 +181,7 @@ impl Keypair for BjjKeypair {
             ret = Self::from_secret(SecretValue::<typenum::U32>::random().as_ref());
         }
 
-        // Not error at this point
+        // Not an error at this point
         ret.unwrap()
     }
 

--- a/src/crypto/lioness.rs
+++ b/src/crypto/lioness.rs
@@ -105,6 +105,8 @@ where
     fn new(key: &Key<Self>, iv: &Iv<Self>) -> Self {
         let k = H::OutputSize::to_usize();
         let i = S::IvSize::to_usize();
+        // These unwraps are safe because the key and iv are
+        // guaranteed to be the correct length by the type system
         Self {
             k1: Array::try_from(&key[0..k]).unwrap(),
             k2: Array::try_from(&key[k..2 * k]).unwrap(),

--- a/src/crypto/lioness.rs
+++ b/src/crypto/lioness.rs
@@ -106,12 +106,12 @@ where
         let k = H::OutputSize::to_usize();
         let i = S::IvSize::to_usize();
         Self {
-            k1: Array::clone_from_slice(&key[0..k]),
-            k2: Array::clone_from_slice(&key[k..2 * k]),
-            k3: Array::clone_from_slice(&key[2 * k..3 * k]),
-            k4: Array::clone_from_slice(&key[3 * k..4 * k]),
-            iv1: Array::clone_from_slice(&iv[0..i]),
-            iv2: Array::clone_from_slice(&iv[i..2 * i]),
+            k1: Array::try_from(&key[0..k]).unwrap(),
+            k2: Array::try_from(&key[k..2 * k]).unwrap(),
+            k3: Array::try_from(&key[2 * k..3 * k]).unwrap(),
+            k4: Array::try_from(&key[3 * k..4 * k]).unwrap(),
+            iv1: Array::try_from(&iv[0..i]).unwrap(),
+            iv2: Array::try_from(&iv[i..2 * i]).unwrap(),
             _phantom: Default::default(),
         }
     }
@@ -154,16 +154,15 @@ where
     /// Performs encryption of the given `block`.
     pub fn encrypt_block(&self, mut block: InOut<'_, '_, Block<Self>>) {
         // L' = L ^ K1
-        let mut left_prime =
-            Array::<u8, <S as KeySizeUser>::KeySize>::clone_from_slice(&block.get_in()[0..Self::K]);
+        let mut left_prime: Array<u8, <S as KeySizeUser>::KeySize> = Default::default();
+        left_prime.copy_from_slice(&block.get_in()[0..Self::K]);
         for i in 0..Self::K {
             left_prime[i] ^= self.k1[i];
         }
 
         // R = R ^ S(L', IV1)
-        let r_cpy = Array::<u8, Diff<B, <S as KeySizeUser>::KeySize>>::clone_from_slice(
-            &block.get_in()[Self::K..B::USIZE],
-        );
+        let mut r_cpy: Array<u8, Diff<B, <S as KeySizeUser>::KeySize>> = Default::default();
+        r_cpy.copy_from_slice(&block.get_in()[Self::K..B::USIZE]);
         S::new(&left_prime, &self.iv1)
             .apply_keystream_b2b(&r_cpy, &mut block.get_out()[Self::K..B::USIZE]);
 
@@ -178,9 +177,8 @@ where
         }
 
         // L' = L ^ K3
-        let mut left_prime = Array::<u8, <S as KeySizeUser>::KeySize>::clone_from_slice(
-            &block.get_out()[0..Self::K],
-        );
+        let mut left_prime: Array<u8, <S as KeySizeUser>::KeySize> = Default::default();
+        left_prime.copy_from_slice(&block.get_out()[0..Self::K]);
         for i in 0..Self::K {
             left_prime[i] ^= self.k3[i];
         }
@@ -211,17 +209,15 @@ where
         }
 
         // L' = L ^ K3
-        let mut left_prime = Array::<u8, <S as KeySizeUser>::KeySize>::clone_from_slice(
-            &block.get_out()[0..Self::K],
-        );
+        let mut left_prime: Array<u8, <S as KeySizeUser>::KeySize> = Default::default();
+        left_prime.copy_from_slice(&block.get_out()[0..Self::K]);
         for i in 0..Self::K {
             left_prime[i] ^= self.k3[i];
         }
 
         // R = R ^ S(L', IV2)
-        let r_cpy = Array::<u8, Diff<B, <S as KeySizeUser>::KeySize>>::clone_from_slice(
-            &block.get_in()[Self::K..B::USIZE],
-        );
+        let mut r_cpy: Array<u8, Diff<B, <S as KeySizeUser>::KeySize>> = Default::default();
+        r_cpy.copy_from_slice(&block.get_in()[Self::K..B::USIZE]);
         S::new(&left_prime, &self.iv2)
             .apply_keystream_b2b(&r_cpy, &mut block.get_out()[Self::K..B::USIZE]);
 
@@ -236,9 +232,8 @@ where
         }
 
         // L' = L ^ K1
-        let mut left_prime = Array::<u8, <S as KeySizeUser>::KeySize>::clone_from_slice(
-            &block.get_out()[0..Self::K],
-        );
+        let mut left_prime: Array<u8, <S as KeySizeUser>::KeySize> = Default::default();
+        left_prime.copy_from_slice(&block.get_out()[0..Self::K]);
         for i in 0..Self::K {
             left_prime[i] ^= self.k1[i];
         }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -36,6 +36,8 @@ pub mod crypto_traits {
 
     pub use elliptic_curve;
 
+    pub use hash2curve;
+
     /// Pseudo-random permutation (PRP)
     pub trait PRP: BlockSizeUser {
         /// Forward permutation

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,7 +6,6 @@ pub mod errors;
 /// the important representations of chain key and packet key.
 pub mod keypairs;
 /// Implementation of the Lioness PRP
-#[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
 pub mod lioness;
 /// Re-exports of low-level cryptographic primitives.
 pub mod primitives;
@@ -34,6 +33,8 @@ pub mod crypto_traits {
         Digest, FixedOutput, FixedOutputReset, HashMarker, Output, OutputSizeUser, Update,
     };
     pub use poly1305::universal_hash::UniversalHash;
+
+    pub use elliptic_curve;
 
     /// Pseudo-random permutation (PRP)
     pub trait PRP: BlockSizeUser {

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -84,7 +84,7 @@ impl<T: KeyIvInit> std::fmt::Debug for IvKey<T> {
     }
 }
 
-#[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
+#[allow(deprecated)]
 impl<T: KeyIvInit> IvKey<T> {
     /// Total size of the key and IV in bytes.
     pub const SIZE: usize = T::KeySize::USIZE + T::IvSize::USIZE;

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -84,7 +84,6 @@ impl<T: KeyIvInit> std::fmt::Debug for IvKey<T> {
     }
 }
 
-#[allow(deprecated)]
 impl<T: KeyIvInit> IvKey<T> {
     /// Total size of the key and IV in bytes.
     pub const SIZE: usize = T::KeySize::USIZE + T::IvSize::USIZE;
@@ -92,7 +91,9 @@ impl<T: KeyIvInit> IvKey<T> {
     /// Returns the IV part.
     #[inline]
     pub fn iv(&self) -> &Iv<T> {
-        Iv::<T>::from_slice(&self.0[0..T::IvSize::USIZE])
+        (&self.0[0..T::IvSize::USIZE])
+            .try_into()
+            .expect("iv is always the correct length")
     }
 
     /// Returns IV as a mutable slice.
@@ -104,7 +105,9 @@ impl<T: KeyIvInit> IvKey<T> {
     /// Returns the key part.
     #[inline]
     pub fn key(&self) -> &Key<T> {
-        Key::<T>::from_slice(&self.0[T::IvSize::USIZE..])
+        (&self.0[T::IvSize::USIZE..])
+            .try_into()
+            .expect("key is always the correct length")
     }
 
     /// Returns the key as a mutable slice.

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -18,8 +18,15 @@ pub use babyjubjub_ec::{
 pub use blake3::{Hasher as Blake3, OutputReader as Blake3Output, hash as blake3_hash};
 /// ChaCha20 stream cipher, re-exported from the [`chacha20`] crate.
 pub use chacha20::ChaCha20;
+/// Curve25519 elliptic curve, re-exported from the [`curve25519_dalek`] crate.
+pub use curve25519_dalek::{
+    edwards::CompressedEdwardsY as Curve25519CompressedPoint,
+    edwards::EdwardsPoint as Curve25519Point,
+    montgomery::MontgomeryPoint as Curve25519MontgomeryPoint, scalar::Scalar as Curve25519Scalar,
+    traits::IsIdentity,
+};
 /// Secp256k1 elliptic curve, re-exported from the [`k256`] crate.
-pub use k256::{CompressedPoint as K256CompressedPoint, Scalar as K256Scalar, Secp256k1};
+pub use k256::Secp256k1;
 /// Poly1305 one-time authenticator, re-exported from the [`poly1305`] crate.
 pub use poly1305::Poly1305;
 /// Keccak-256 and SHA3-256 hash functions, re-exported from the [`sha3`] crate.

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -145,7 +145,6 @@ impl Challenge {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HalfKey(#[cfg_attr(feature = "serde", serde(with = "serde_bytes"))] [u8; Self::SIZE]);
 
-#[allow(deprecated)]
 impl Default for HalfKey {
     fn default() -> Self {
         let mut ret = Self([0u8; Self::SIZE]);
@@ -923,7 +922,6 @@ impl Display for Response {
     }
 }
 
-#[allow(deprecated)]
 impl Response {
     /// Converts this response to the PoR challenge by turning the non-zero scalar
     /// represented by this response into a secp256k1 curve point (public key).

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -4,7 +4,7 @@ use curve25519_dalek::{
 };
 use digest::Digest;
 use elliptic_curve::NonZeroScalar;
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use k256::{
     AffinePoint, Secp256k1,
     elliptic_curve::{
@@ -145,7 +145,7 @@ impl Challenge {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HalfKey(#[cfg_attr(feature = "serde", serde(with = "serde_bytes"))] [u8; Self::SIZE]);
 
-#[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
+#[allow(deprecated)]
 impl Default for HalfKey {
     fn default() -> Self {
         let mut ret = Self([0u8; Self::SIZE]);
@@ -564,9 +564,9 @@ impl From<&OffchainPublicKey> for EdwardsPoint {
     }
 }
 
-impl<'a> From<&'a OffchainPublicKey> for &'a GenericArray<u8, typenum::U32> {
-    fn from(value: &'a OffchainPublicKey) -> &'a GenericArray<u8, typenum::U32> {
-        GenericArray::from_slice(&value.compressed.0)
+impl<'a> From<&'a OffchainPublicKey> for &'a Array<u8, typenum::U32> {
+    fn from(value: &'a OffchainPublicKey) -> &'a Array<u8, typenum::U32> {
+        Array::cast_from_core(&value.compressed.0)
     }
 }
 
@@ -899,9 +899,9 @@ impl From<&PublicKey> for k256::ProjectivePoint {
     }
 }
 
-impl<'a> From<&'a PublicKey> for &'a GenericArray<u8, typenum::U33> {
-    fn from(value: &'a PublicKey) -> &'a GenericArray<u8, typenum::U33> {
-        GenericArray::from_slice(&value.1)
+impl<'a> From<&'a PublicKey> for &'a Array<u8, typenum::U33> {
+    fn from(value: &'a PublicKey) -> &'a Array<u8, typenum::U33> {
+        Array::cast_from_core(&value.1)
     }
 }
 
@@ -923,7 +923,7 @@ impl Display for Response {
     }
 }
 
-#[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
+#[allow(deprecated)]
 impl Response {
     /// Converts this response to the PoR challenge by turning the non-zero scalar
     /// represented by this response into a secp256k1 curve point (public key).

--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -1,6 +1,6 @@
 use crate::crypto_random::{Randomizable, random_array};
-use generic_array::{ArrayLength, GenericArray};
 use hash2curve::ExpandMsgXmd;
+use hybrid_array::{Array, ArraySize};
 use k256::{
     AffinePoint, Secp256k1,
     elliptic_curve::{PrimeField, point::NonIdentity},
@@ -62,7 +62,7 @@ pub fn x25519_scalar_from_bytes(
 
 /// Creates secp256k1 secret scalar from the given bytes.
 /// Note that this function allows zero scalars.
-#[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
+#[allow(deprecated)]
 pub fn k256_scalar_from_bytes(bytes: &[u8]) -> crate::crypto::errors::Result<k256::Scalar> {
     if bytes.len() == k256::elliptic_curve::FieldBytesSize::<Secp256k1>::to_usize() {
         Option::from(k256::Scalar::from_repr(*k256::FieldBytes::from_slice(
@@ -103,57 +103,59 @@ pub fn sample_secp256k1_field_element(
 /// Secret values are always compared in constant time.
 /// The default value is all zeroes.
 #[derive(Clone, zeroize::ZeroizeOnDrop)]
-pub struct SecretValue<L: ArrayLength>(GenericArray<u8, L>);
+pub struct SecretValue<L: ArraySize>(Array<u8, L>);
 
-impl<L: ArrayLength> ConstantTimeEq for SecretValue<L> {
+impl<L: ArraySize> ConstantTimeEq for SecretValue<L> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
-impl<L: ArrayLength> AsRef<[u8]> for SecretValue<L> {
+impl<L: ArraySize> AsRef<[u8]> for SecretValue<L> {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl<L: ArrayLength> From<GenericArray<u8, L>> for SecretValue<L> {
-    fn from(value: GenericArray<u8, L>) -> Self {
+impl<L: ArraySize> From<Array<u8, L>> for SecretValue<L> {
+    fn from(value: Array<u8, L>) -> Self {
         Self(value)
     }
 }
 
-impl<'a, L: ArrayLength> From<&'a SecretValue<L>> for &'a GenericArray<u8, L> {
+impl<'a, L: ArraySize> From<&'a SecretValue<L>> for &'a Array<u8, L> {
     fn from(value: &'a SecretValue<L>) -> Self {
         &value.0
     }
 }
 
-impl<L: ArrayLength> TryFrom<&[u8]> for SecretValue<L> {
+impl<L: ArraySize> TryFrom<&[u8]> for SecretValue<L> {
     type Error = CryptoError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() == Self::LENGTH {
-            Ok(Self(GenericArray::from_slice(value).clone()))
+            let mut arr: Array<u8, L> = Default::default();
+            arr.copy_from_slice(value);
+            Ok(Self(arr))
         } else {
             Err(InvalidInputValue("value"))
         }
     }
 }
 
-impl<L: ArrayLength> Default for SecretValue<L> {
+impl<L: ArraySize> Default for SecretValue<L> {
     fn default() -> Self {
-        Self(GenericArray::default())
+        Self(Array::default())
     }
 }
 
-impl<L: ArrayLength> AsMut<[u8]> for SecretValue<L> {
+impl<L: ArraySize> AsMut<[u8]> for SecretValue<L> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
 }
 
-impl<L: ArrayLength> From<SecretValue<L>> for Box<[u8]> {
+impl<L: ArraySize> From<SecretValue<L>> for Box<[u8]> {
     fn from(value: SecretValue<L>) -> Self {
         value.as_ref().into()
     }
@@ -161,24 +163,24 @@ impl<L: ArrayLength> From<SecretValue<L>> for Box<[u8]> {
 
 impl From<SecretValue<typenum::U32>> for [u8; 32] {
     fn from(value: SecretValue<typenum::U32>) -> Self {
-        value.0.into_array()
+        value.0.0
     }
 }
 
 impl From<[u8; 32]> for SecretValue<typenum::U32> {
     fn from(value: [u8; 32]) -> Self {
-        Self(value.into())
+        Self(Array(value))
     }
 }
 
-impl<L: ArrayLength> std::fmt::Debug for SecretValue<L> {
+impl<L: ArraySize> std::fmt::Debug for SecretValue<L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("SecretValue").field(&"<redacted>").finish()
     }
 }
 
 #[cfg(feature = "serde")]
-impl<L: ArrayLength> serde::Serialize for SecretValue<L> {
+impl<L: ArraySize> serde::Serialize for SecretValue<L> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -188,21 +190,21 @@ impl<L: ArrayLength> serde::Serialize for SecretValue<L> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, L: ArrayLength> serde::Deserialize<'de> for SecretValue<L> {
+impl<'de, L: ArraySize> serde::Deserialize<'de> for SecretValue<L> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        Ok(Self(GenericArray::deserialize(deserializer)?))
+        Ok(Self(Array::deserialize(deserializer)?))
     }
 }
 
-impl<L: ArrayLength> SecretValue<L> {
+impl<L: ArraySize> SecretValue<L> {
     /// Length of the secret value in bytes.
     pub const LENGTH: usize = L::USIZE;
 }
 
-impl<L: ArrayLength> Randomizable for SecretValue<L> {
+impl<L: ArraySize> Randomizable for SecretValue<L> {
     /// Generates cryptographically strong random secret value.
     fn random() -> Self {
         Self(random_array())

--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -62,12 +62,11 @@ pub fn x25519_scalar_from_bytes(
 
 /// Creates secp256k1 secret scalar from the given bytes.
 /// Note that this function allows zero scalars.
-#[allow(deprecated)]
 pub fn k256_scalar_from_bytes(bytes: &[u8]) -> crate::crypto::errors::Result<k256::Scalar> {
     if bytes.len() == k256::elliptic_curve::FieldBytesSize::<Secp256k1>::to_usize() {
-        Option::from(k256::Scalar::from_repr(*k256::FieldBytes::from_slice(
-            bytes,
-        )))
+        Option::from(k256::Scalar::from_repr(
+            k256::FieldBytes::try_from(bytes).map_err(|_| InvalidInputValue("bytes"))?,
+        ))
         .ok_or(InvalidInputValue("bytes"))
     } else {
         Err(InvalidInputValue("bytes"))

--- a/src/crypto_random/mod.rs
+++ b/src/crypto_random/mod.rs
@@ -4,7 +4,7 @@
 //! Instead of relying on external crates, all HOPR crates in this monorepo should
 //! exclusively rely on randomness functions only from this crate.
 
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 /// Re-export of the [`Rng`] trait for generic random value generation.
 pub use rand::Rng;
 use rand::{CryptoRng, RngExt};
@@ -94,9 +94,9 @@ pub fn random_bytes<const T: usize>() -> [u8; T] {
     ret
 }
 
-/// Allocates `GenericArray` of the given size and fills it with random bytes
-pub fn random_array<L: ArrayLength>() -> GenericArray<u8, L> {
-    let mut ret = GenericArray::default();
+/// Allocates `Array` of the given size and fills it with random bytes
+pub fn random_array<L: ArraySize>() -> Array<u8, L> {
+    let mut ret = Array::default();
     random_fill(&mut ret);
     ret
 }

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -16,6 +16,9 @@ pub mod traits;
 /// Re-exports of the `typenum` crate.
 pub use typenum;
 
+/// Re-exports of the `hybrid_array` crate.
+pub use hybrid_array;
+
 /// Approximately compares two double-precision floats.
 ///
 /// This function first tests if the two values relatively differ by at least `epsilon`.


### PR DESCRIPTION
Replace `generic-array` 1.4.3 with `hybrid-array` 0.4.13, which
provides safe const-generic-backed arrays compatible with the
crypto-common/cipher crate ecosystem:

- Replace `GenericArray<T, L>` / `ArrayLength` with `Array<T, U>` / `ArraySize`
- Update `SecretValue<L>` inner type and all associated impls
- Replace `GenericArray::from_slice()` / `clone_from_slice()` with
  `Default::default()` + `copy_from_slice()` (those methods are deprecated
  in hybrid-array)
- Use `Array::cast_from_core()` for zero-cost ref conversions from `[u8; N]`
- Use `Array(secret)` literal construction instead of `GenericArray::from(secret)`
- Remove all `#[allow(deprecated)]` comments referencing generic-array
- Add `pub use hybrid_array` to primitive re-exports
- Update Cargo features: `generic-array/{zeroize,serde}` → `hybrid-array/{zeroize,serde}`

Additionally, also re-export `elliptic-curve` and enable additional features on `k256` crate.