### PR TITLE
fix(nix): add Dependabot for nix flake.lock updates, disable Renovate nix manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:
+  # it requires running `nix flake update` (to compute narHash values), but the
+  # sandboxed jr-microvm environment has no nix binary and allowedCommands is locked
+  # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
+  # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
+  # instead; the nix manager is disabled in renovate.json.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    groups:
+      nix-flake-inputs:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       day: "monday"
       time: "02:00"
       timezone: "UTC"
+    cooldown:
+      default: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       time: "02:00"
       timezone: "UTC"
     cooldown:
-      default: 7
+      default-days: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       timezone: "UTC"
     cooldown:
       default-days: 7
+    ignore:
+      # nix-lib uses version-pinned refs (github:hoprnet/nix-lib/vX.Y.Z) that
+      # Dependabot compares incorrectly and proposes as a downgrade. Version
+      # upgrades are managed manually alongside breaking API changes.
+      - dependency-name: "nix-lib"
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,7 +110,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@84aa568b19be3f1185e9c61afd5dfbf8f13913a0 # build-library-v3.1.3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,7 +110,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@84aa568b19be3f1185e9c61afd5dfbf8f13913a0 # build-library-v3.1.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@475421441ff5747c2233ebe58cdff355c8b40356 # build-library-v3.1.3
     permissions:
       contents: read
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -4323,9 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/flake.lock
+++ b/flake.lock
@@ -158,16 +158,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776558870,
-        "narHash": "sha256-G/lO0LFVpJa6cTe3KK5LBECDgx2aDZR+zq3T2HlAPeo=",
+        "lastModified": 1785422677,
+        "narHash": "sha256-kqeEj7b2Q8m8QWuFShZbBnv4XI0/GI7/yHnJP63zA+A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d00f15b51da51899c4b7860b67f7f87b95feca97",
+        "rev": "424477091899edd00863d8a1f48b703790baacb1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -144,14 +144,6 @@
                 language = "system";
                 pass_filenames = false;
               };
-              dependabot-validator = {
-                enable = true;
-                name = "Dependabot config validator";
-                entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
-                files = "\\.github/dependabot\\.yml$";
-                language = "system";
-                pass_filenames = true;
-              };
             };
             excludes = sharedExcludes ++ [
               "vendor/"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # Core Nix ecosystem dependencies
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
@@ -143,6 +143,14 @@
                 files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;
+              };
+              dependabot-validator = {
+                enable = true;
+                name = "Dependabot config validator";
+                entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
+                files = "\\.github/dependabot\\.yml$";
+                language = "system";
+                pass_filenames = true;
               };
             };
             excludes = sharedExcludes ++ [

--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,14 @@
                 language = "system";
                 pass_filenames = false;
               };
+              dependabot-validator = {
+                enable = true;
+                name = "Dependabot config validator";
+                entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
+                files = "\\.github/dependabot\\.yml$";
+                language = "system";
+                pass_filenames = true;
+              };
             };
             excludes = sharedExcludes ++ [
               "vendor/"

--- a/renovate.json
+++ b/renovate.json
@@ -11,48 +11,54 @@
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
   "pinDigests": true,
-  "nix": { "enabled": true },
+  "nix": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"],
+    "labels": [
+      "security"
+    ],
+    "schedule": [
+      "at any time"
+    ],
     "automerge": true
   },
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
     },
     {
-      "matchManagers": ["nix"],
-      "groupName": "nix flake updates",
-      "commitMessageTopic": "Nix flake inputs"
-    },
-    {
-      "description": "Expedite nix security updates — bypass weekly schedule",
-      "matchManagers": ["nix"],
-      "matchCategories": ["security"],
-      "schedule": ["at any time"],
-      "automerge": true,
-      "labels": ["security"],
-      "groupName": "nix security updates",
-      "commitMessageTopic": "Nix security updates"
-    },
-    {
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "cargo dependencies",
       "commitMessageTopic": "Cargo dependencies"
     },
     {
-      "description": "Expedite cargo security updates — bypass weekly schedule",
-      "matchManagers": ["cargo"],
-      "matchCategories": ["security"],
-      "schedule": ["at any time"],
+      "description": "Expedite cargo security updates \u2014 bypass weekly schedule",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchCategories": [
+        "security"
+      ],
+      "schedule": [
+        "at any time"
+      ],
       "automerge": true,
-      "labels": ["security"],
+      "labels": [
+        "security"
+      ],
       "groupName": "cargo security updates",
       "commitMessageTopic": "Cargo security updates"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -16,49 +16,30 @@
   },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": [
-      "security"
-    ],
-    "schedule": [
-      "at any time"
-    ],
+    "labels": ["security"],
+    "schedule": ["at any time"],
     "automerge": true
   },
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "cargo dependencies",
       "commitMessageTopic": "Cargo dependencies"
     },
     {
       "description": "Expedite cargo security updates \u2014 bypass weekly schedule",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchCategories": [
-        "security"
-      ],
-      "schedule": [
-        "at any time"
-      ],
+      "matchManagers": ["cargo"],
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
       "automerge": true,
-      "labels": [
-        "security"
-      ],
+      "labels": ["security"],
       "groupName": "cargo security updates",
       "commitMessageTopic": "Cargo security updates"
     }


### PR DESCRIPTION
Renovate's `nix` manager cannot update `flake.lock` on Mend-hosted infrastructure — the sandboxed runner has no `nix` binary and `allowedCommands` is restricted to `git add/reset/pwd`, causing a level-40 "Digest is not updated" error every Monday. Switches to Dependabot's native nix ecosystem support (2026-04-07), which monitors `flake.lock` weekly and groups all inputs into a single PR via `nix-flake-inputs`; disables the Renovate nix manager; adds a `dependabot-validator` pre-commit hook (`check-jsonschema` ≥ 0.37.2 from nixpkgs 26.05); and sets a 7-day cooldown to satisfy the zizmor `insufficient-cooldown` audit.

---
**Additional fix**: upgraded `ruint` to 1.20.0 to resolve RUSTSEC-2026-0220 (uint shift overflow).