### PR TITLE
feat: move PIX deposit address and secret types into hopr-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -1528,18 +1528,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1824,22 +1824,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -1848,7 +1832,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rand_core 0.10.1",
  "rustc_version 0.4.1",
  "serde",
@@ -1918,15 +1902,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1934,12 +1918,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2040,13 +2024,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2100,16 +2084,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
@@ -2121,26 +2095,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
+ "curve25519-dalek",
+ "ed25519",
  "keccak",
  "rand_core 0.10.1",
  "serde",
@@ -2204,7 +2164,7 @@ dependencies = [
  "digest 0.11.3",
  "ff 0.14.0",
  "group 0.14.0",
- "hkdf 0.13.0",
+ "hkdf",
  "hybrid-array",
  "pkcs8 0.11.0",
  "rand_core 0.10.1",
@@ -2234,22 +2194,22 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2315,12 +2275,6 @@ dependencies = [
  "rand_core 0.10.1",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -2678,15 +2632,6 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
@@ -2714,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.0"
+version = "4.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
+checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2750,9 +2695,9 @@ dependencies = [
  "const-hex",
  "criterion",
  "ctr",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "digest 0.11.3",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "elliptic-curve 0.14.1",
  "float-cmp",
  "hash2curve",
@@ -2799,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2838,9 +2783,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "serde",
  "subtle",
@@ -3099,7 +3044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -3130,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -3264,18 +3209,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.14"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+checksum = "3d77f16caa4f4d2667a1fad5bb1a3a4a4556967c1bff93525ebb2975847fa3de"
 dependencies = [
  "bs58",
- "ed25519-dalek 2.2.0",
- "hkdf 0.12.4",
+ "ed25519-dalek",
+ "hkdf",
  "multihash",
  "prost",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror",
  "tracing",
  "zeroize",
@@ -3384,12 +3329,13 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+checksum = "d96879ec0057cf5f99543c5333f6818c1473081684ae7ad55da21b6ea65ba214"
 dependencies = [
  "arrayref",
  "byteorder",
+ "bytes",
  "data-encoding",
  "libp2p-identity",
  "multibase",
@@ -4235,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4438,9 +4384,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4628,7 +4574,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.11.4",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -5022,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5102,13 +5048,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5159,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,11 +116,11 @@ telemetry = [
 ]
 
 [dependencies]
-aes = { version = "0.9.1", optional = true }
-anyhow = { version = "1.0.103", optional = true }
+aes = { version = "0.9.2", optional = true }
+anyhow = { version = "1.0.104", optional = true }
 aquamarine = { version = "0.6.0", optional = true }
 arrayvec = { version = "0.7.8", optional = true }
-async-trait = { version = "0.1.89", optional = true }
+async-trait = { version = "0.1.91", optional = true }
 babyjubjub-ec = { version = "0.4.0", optional = true, features = [
   "hash2curve",
   "arithmetic",
@@ -145,7 +145,7 @@ ed25519-dalek = { version = "3.0.0", optional = true, features = [
   "batch",
 ] }
 float-cmp = { version = "0.10.0", optional = true }
-hybrid-array = { version = "0.4.13", features = [
+hybrid-array = { version = "0.4.14", features = [
   "extra-sizes",
 ], optional = true }
 const-hex = { version = "1.19.1", optional = true, default-features = false, features = [
@@ -153,7 +153,7 @@ const-hex = { version = "1.19.1", optional = true, default-features = false, fea
 ] }
 hash2curve = { version = "0.14.0", optional = true }
 hex-literal = { version = "1.1.0", optional = true }
-hopr-bindings = { version = "4.12.0", optional = true }
+hopr-bindings = { version = "4.12.1", optional = true }
 k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
@@ -161,12 +161,12 @@ k256 = { version = "0.14.0", optional = true, features = [
   "group-digest",
 ] }
 lazy_static = { version = "1.5.0", optional = true }
-libp2p-identity = { version = "0.2.14", optional = true, features = [
+libp2p-identity = { version = "0.3.0", optional = true, features = [
   "peerid",
   "ed25519",
   "rand",
 ] }
-multiaddr = { version = "0.18.2", optional = true }
+multiaddr = { version = "0.19.0", optional = true }
 num_enum = { version = "0.7.6", optional = true }
 opentelemetry = { version = "0.32.0", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.32.1", optional = true, features = [
@@ -178,7 +178,7 @@ poly1305 = { version = "0.9.1", optional = true }
 primitive-types = { version = "0.14.0", optional = true }
 rand = { version = "0.10.2", optional = true, features = ["thread_rng"] }
 rayon = { version = "1.12.0", optional = true }
-regex = { version = "1.13.0", optional = true }
+regex = { version = "1.13.1", optional = true }
 rlp = { version = "0.6.1", optional = true }
 secp256k1 = { version = "0.31.1", optional = true, default-features = false, features = [
   "alloc",
@@ -189,21 +189,21 @@ secp256k1 = { version = "0.31.1", optional = true, default-features = false, fea
 scrypt = { version = "0.12.0", optional = true, default-features = false, features = [
   "phc",
 ] }
-serde = { version = "1.0.228", optional = true, features = ["derive"] }
+serde = { version = "1.0.229", optional = true, features = ["derive"] }
 serde_bytes = { version = "0.11.19", optional = true }
-serde_json = { version = "1.0.150", optional = true }
+serde_json = { version = "1.0.151", optional = true }
 serde_with = { version = "3.21.0", optional = true }
 sha2 = { version = "0.11.0", optional = true }
 sha3 = { version = "0.12.0", optional = true }
 smart-default = { version = "0.7.1", optional = true }
 strum = { version = "0.28.0", optional = true, features = ["derive"] }
 subtle = { version = "2.6.1", optional = true }
-thiserror = { version = "2.0.18", optional = true }
+thiserror = { version = "2.0.19", optional = true }
 tracing = { version = "0.1.44", optional = true, features = [
   "release_max_level_debug",
 ] }
 typenum = { version = "1.20.1", optional = true }
-uuid = { version = "1.23.4", optional = true, features = ["serde", "v4"] }
+uuid = { version = "1.24.0", optional = true, features = ["serde", "v4"] }
 zeroize = { version = "1.9.0", optional = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
@@ -221,7 +221,7 @@ postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 serde = "1.0.228"
 serde_json = "1.0.150"
 tempfile = "3.27.0"
-tokio = { version = "1.52.3", features = [
+tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "macros",
   "tracing",

--- a/src/chain/parser.rs
+++ b/src/chain/parser.rs
@@ -303,7 +303,6 @@ mod tests {
         prelude::{ChainKeypair, HalfKey, Hash, Keypair, OffchainKeypair, Response},
     };
     use crate::internal::prelude::{AnnouncementData, KeyBinding, TicketBuilder};
-    use hex_literal::hex;
 
     use super::*;
     use crate::chain::payload::tests::{CONTRACT_ADDRS_JSON, PRIVATE_KEY_1, PRIVATE_KEY_2};

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -137,6 +137,23 @@ impl<T: KeyIvInit> IvKey<T> {
 }
 
 /// An address representing a PIX deposit.
+///
+/// ```rust
+/// use hopr_types::primitive::prelude::Address;
+/// use hopr_types::crypto::types::BjjPublicKey;
+/// use hopr_types::crypto::keypairs::{Keypair, BjjKeypair, ChainKeypair};
+/// use hopr_types::crypto::prelude::PixDepositAddress;
+///
+/// let pub_key_1 = *BjjKeypair::random().public();
+/// let pub_key_2: PixDepositAddress = pub_key_1.into();
+///
+/// assert_eq!(pub_key_1, pub_key_2.try_into().unwrap());
+///
+/// let pub_key_1 = ChainKeypair::random().public().to_address();
+/// let pub_key_2: PixDepositAddress = pub_key_1.into();
+///
+/// assert_eq!(pub_key_1, pub_key_2.try_into().unwrap());
+/// ```
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, strum::EnumDiscriminants)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[strum_discriminants(vis(pub))]

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -142,16 +142,18 @@ impl<T: KeyIvInit> IvKey<T> {
 /// use hopr_types::primitive::prelude::Address;
 /// use hopr_types::crypto::types::BjjPublicKey;
 /// use hopr_types::crypto::keypairs::{Keypair, BjjKeypair, ChainKeypair};
-/// use hopr_types::crypto::prelude::PixDepositAddress;
+/// use hopr_types::crypto::prelude::{PixDepositAddress, PixDepositAddressDiscriminants};
 ///
 /// let pub_key_1 = *BjjKeypair::random().public();
 /// let pub_key_2: PixDepositAddress = pub_key_1.into();
 ///
+/// assert_eq!(PixDepositAddressDiscriminants::Bjj, pub_key_2.address_type());
 /// assert_eq!(pub_key_1, pub_key_2.try_into().unwrap());
 ///
 /// let pub_key_1 = ChainKeypair::random().public().to_address();
 /// let pub_key_2: PixDepositAddress = pub_key_1.into();
 ///
+/// assert_eq!(PixDepositAddressDiscriminants::Eth, pub_key_2.address_type());
 /// assert_eq!(pub_key_1, pub_key_2.try_into().unwrap());
 /// ```
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, strum::EnumDiscriminants)]

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -10,6 +10,8 @@ use crate::crypto::{
 /// AES with 128-bit key in counter-mode (with big-endian counter).
 pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
+use crate::crypto::prelude::BjjPublicKey;
+use crate::primitive::prelude::{Address, GeneralError};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{
     BabyJubJub, GroupRepr as BabyJubJubCompressedPoint, Scalar as BabyJubJubScalar,
@@ -31,6 +33,7 @@ pub use k256::Secp256k1;
 pub use poly1305::Poly1305;
 /// Keccak-256 and SHA3-256 hash functions, re-exported from the [`sha3`] crate.
 pub use sha3::{Keccak256, Sha3_256};
+use strum::IntoDiscriminant;
 
 /// Represents a 256-bit secret key of fixed length.
 /// The value is auto-zeroized on drop.
@@ -132,3 +135,76 @@ impl<T: KeyIvInit> IvKey<T> {
         V::new(self.key(), self.iv())
     }
 }
+
+/// An address representing a PIX deposit.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, strum::EnumDiscriminants)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[strum_discriminants(vis(pub))]
+#[strum_discriminants(derive(strum::FromRepr, strum::EnumCount), repr(u8))]
+#[cfg_attr(
+    feature = "serde",
+    strum_discriminants(derive(serde::Serialize, serde::Deserialize))
+)]
+pub enum PixDepositAddress {
+    /// [`Address`]-based PIX deposit address.
+    Eth(Address),
+    /// [`BjjPublicKey`]-based PIX deposit address.
+    Bjj(BjjPublicKey),
+}
+
+impl PixDepositAddress {
+    /// Returns the address type of this deposit address.
+    #[inline]
+    pub fn address_type(&self) -> PixDepositAddressDiscriminants {
+        self.discriminant()
+    }
+}
+
+impl AsRef<[u8]> for PixDepositAddress {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            PixDepositAddress::Eth(key) => key.as_ref(),
+            PixDepositAddress::Bjj(key) => key.as_ref(),
+        }
+    }
+}
+
+impl From<Address> for PixDepositAddress {
+    fn from(value: Address) -> Self {
+        Self::Eth(value)
+    }
+}
+
+impl TryFrom<PixDepositAddress> for Address {
+    type Error = GeneralError;
+
+    fn try_from(value: PixDepositAddress) -> Result<Self, Self::Error> {
+        match value {
+            PixDepositAddress::Eth(a) => Ok(a),
+            PixDepositAddress::Bjj(_) => Err(GeneralError::InvalidInput),
+        }
+    }
+}
+
+impl From<BjjPublicKey> for PixDepositAddress {
+    fn from(value: BjjPublicKey) -> Self {
+        Self::Bjj(value)
+    }
+}
+
+impl TryFrom<PixDepositAddress> for BjjPublicKey {
+    type Error = GeneralError;
+
+    fn try_from(value: PixDepositAddress) -> Result<Self, Self::Error> {
+        match value {
+            PixDepositAddress::Bjj(a) => Ok(a),
+            PixDepositAddress::Eth(_) => Err(GeneralError::InvalidInput),
+        }
+    }
+}
+
+/// A secret corresponding to a PIX deposit address.
+///
+/// Usually the [`PixDepositAddress`] can be calculated from the secret.
+#[derive(Clone, Debug)]
+pub struct PixDepositSecret(pub SecretValue<typenum::U32>);

--- a/src/keypair/key_pair.rs
+++ b/src/keypair/key_pair.rs
@@ -116,6 +116,7 @@ impl FromStr for HoprKeys {
     /// use std::str::FromStr;
     /// use hopr_types::keypair::key_pair::HoprKeys;
     /// use hopr_types::crypto_random::Randomizable;
+    /// use hopr_types::crypto::keypairs::Keypair;
     ///
     /// let keys = HoprKeys::random();
     /// let hex = format!("0x{}", const_hex::encode(&[

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -7,8 +7,8 @@ pub mod balance;
 pub mod bounded;
 /// Lists all errors in this crate.
 pub mod errors;
-/// Implements the most primitive types, such as [U256](crate::primitive::primitives::U256) or
-/// [Address](crate::primitive::primitives::Address).
+/// Implements the most primitive types, such as [U256](primitives::U256) or
+/// [Address](primitives::Address).
 pub mod primitives;
 /// Defines commonly used traits across the entire code base.
 pub mod traits;
@@ -18,6 +18,9 @@ pub use typenum;
 
 /// Re-exports of the `hybrid_array` crate.
 pub use hybrid_array;
+
+/// Re-exports of the `multiaddr` crate.
+pub use multiaddr;
 
 /// Approximately compares two double-precision floats.
 ///


### PR DESCRIPTION
As in title.

Also update dependencies, and re-export `multiaddr` crate.