### PR TITLE
chore: downgrade libp2p-identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,22 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -1832,7 +1848,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
- "fiat-crypto",
+ "fiat-crypto 0.3.0",
  "rand_core 0.10.1",
  "rustc_version 0.4.1",
  "serde",
@@ -2084,6 +2100,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
@@ -2095,12 +2121,26 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
  "keccak",
  "rand_core 0.10.1",
  "serde",
@@ -2164,7 +2204,7 @@ dependencies = [
  "digest 0.11.3",
  "ff 0.14.0",
  "group 0.14.0",
- "hkdf",
+ "hkdf 0.13.0",
  "hybrid-array",
  "pkcs8 0.11.0",
  "rand_core 0.10.1",
@@ -2275,6 +2315,12 @@ dependencies = [
  "rand_core 0.10.1",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -2632,6 +2678,15 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
@@ -2695,9 +2750,9 @@ dependencies = [
  "const-hex",
  "criterion",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "digest 0.11.3",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "elliptic-curve 0.14.1",
  "float-cmp",
  "hash2curve",
@@ -2707,7 +2762,7 @@ dependencies = [
  "insta",
  "k256 0.14.0",
  "lazy_static",
- "libp2p-identity",
+ "libp2p-identity 0.2.14",
  "mockall",
  "multiaddr",
  "num_enum",
@@ -3209,21 +3264,35 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "bs58",
+ "ed25519-dalek 2.2.0",
+ "hkdf 0.12.4",
+ "multihash",
+ "prost",
+ "rand 0.8.7",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-identity"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d77f16caa4f4d2667a1fad5bb1a3a4a4556967c1bff93525ebb2975847fa3de"
 dependencies = [
  "bs58",
- "ed25519-dalek",
- "hkdf",
+ "hkdf 0.13.0",
  "multihash",
- "prost",
- "rand 0.10.2",
- "serde",
  "sha2 0.11.0",
  "thiserror",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -3337,7 +3406,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "libp2p-identity",
+ "libp2p-identity 0.3.0",
  "multibase",
  "multihash",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
  "insta",
  "k256 0.14.0",
  "lazy_static",
- "libp2p-identity 0.2.14",
+ "libp2p-identity",
  "mockall",
  "multiaddr",
  "num_enum",
@@ -3282,20 +3282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-identity"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d77f16caa4f4d2667a1fad5bb1a3a4a4556967c1bff93525ebb2975847fa3de"
-dependencies = [
- "bs58",
- "hkdf 0.13.0",
- "multihash",
- "sha2 0.11.0",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,15 +3384,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.19.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96879ec0057cf5f99543c5333f6818c1473081684ae7ad55da21b6ea65ba214"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
- "bytes",
  "data-encoding",
- "libp2p-identity 0.3.0",
+ "libp2p-identity",
  "multibase",
  "multihash",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,8 @@ libp2p-identity = { version = "0.2.14", optional = true, features = [
   "ed25519",
   "rand",
 ] }
-multiaddr = { version = "0.19.0", optional = true }
+# pinned due to libp2p-identity
+multiaddr = { version = "0.18.2", optional = true }
 num_enum = { version = "0.7.6", optional = true }
 opentelemetry = { version = "0.32.0", optional = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.32.1", optional = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,8 @@ k256 = { version = "0.14.0", optional = true, features = [
   "group-digest",
 ] }
 lazy_static = { version = "1.5.0", optional = true }
-libp2p-identity = { version = "0.3.0", optional = true, features = [
+# do not update libp2p-identity until new libp2p version
+libp2p-identity = { version = "0.2.14", optional = true, features = [
   "peerid",
   "ed25519",
   "rand",


### PR DESCRIPTION
As in title. Should be upgraded only with new libp2p version