### PR TITLE
feat: add PixDeposit support for keypairs and address conversion

### DIFF
--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -13,6 +13,7 @@ use crate::crypto::types::BjjPublicKey;
 use crate::crypto::{
     errors,
     errors::CryptoError::InvalidInputValue,
+    primitives::{PixDepositAddress, PixDepositSecret},
     types::{OffchainPublicKey, PublicKey},
     utils::{SecretValue, k256_scalar_from_bytes, random_group_element, x25519_scalar_from_bytes},
 };
@@ -210,6 +211,28 @@ impl From<&BjjKeypair> for BjjPublicKey {
     }
 }
 
+/// Extension trait for keypairs that can be used as PIX deposit/withdrawal keys.
+///
+/// This trait is automatically implemented for all keypairs, where the public key is convertible into [`PixDepositAddress`]
+/// and the secret key is sized so that it also fits the [`PixDepositSecret`].
+pub trait PixKeypairExt: Keypair<SecretLen = typenum::U32>
+where
+    <Self as Keypair>::Public: Into<PixDepositAddress>,
+{
+    /// Consumes the instance and produces corresponding [`PixDepositSecret`] and [`PixDepositAddress`].
+    fn unzip_into_pix(self) -> (PixDepositSecret, PixDepositAddress) {
+        let (secret, public) = self.unzip();
+        (secret.into(), public.into())
+    }
+}
+
+impl<K> PixKeypairExt for K
+where
+    K: Keypair<SecretLen = typenum::U32>,
+    <K as Keypair>::Public: Into<PixDepositAddress>,
+{
+}
+
 #[cfg(test)]
 mod tests {
     use libp2p_identity::PeerId;
@@ -291,10 +314,15 @@ mod tests {
             "keypair public keys must be equal"
         );
 
-        let (s1, p1) = kp_1.unzip();
-        let (s2, p2) = kp_2.unzip();
+        let (s1, p1) = kp_1.clone().unzip();
+        let (s2, p2) = kp_2.clone().unzip();
 
         assert_eq!(s1.ct_eq(&s2).unwrap_u8(), 1);
+        assert_eq!(p1, p2);
+
+        let (s1, p1) = kp_1.unzip_into_pix();
+        let (s2, p2) = kp_2.unzip_into_pix();
+        assert_eq!(s1.0.ct_eq(&s2.0).unwrap_u8(), 1);
         assert_eq!(p1, p2);
     }
 
@@ -331,10 +359,15 @@ mod tests {
             "keypair public keys must be equal"
         );
 
-        let (s1, p1) = kp_1.unzip();
-        let (s2, p2) = kp_2.unzip();
+        let (s1, p1) = kp_1.clone().unzip();
+        let (s2, p2) = kp_2.clone().unzip();
 
         assert_eq!(s1.ct_eq(&s2).unwrap_u8(), 1);
+        assert_eq!(p1, p2);
+
+        let (s1, p1) = kp_1.unzip_into_pix();
+        let (s2, p2) = kp_2.unzip_into_pix();
+        assert_eq!(s1.0.ct_eq(&s2.0).unwrap_u8(), 1);
         assert_eq!(p1, p2);
     }
 }

--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -320,10 +320,9 @@ mod tests {
         assert_eq!(s1.ct_eq(&s2).unwrap_u8(), 1);
         assert_eq!(p1, p2);
 
-        let (s1, p1) = kp_1.unzip_into_pix();
-        let (s2, p2) = kp_2.unzip_into_pix();
-        assert_eq!(s1.0.ct_eq(&s2.0).unwrap_u8(), 1);
-        assert_eq!(p1, p2);
+        let (s1, p1) = kp_1.clone().unzip_into_pix();
+        assert_eq!(s1.0.ct_eq(&kp_1.secret()).unwrap_u8(), 1);
+        assert_eq!(p1, kp_1.public().clone().into());
     }
 
     #[test]
@@ -365,9 +364,8 @@ mod tests {
         assert_eq!(s1.ct_eq(&s2).unwrap_u8(), 1);
         assert_eq!(p1, p2);
 
-        let (s1, p1) = kp_1.unzip_into_pix();
-        let (s2, p2) = kp_2.unzip_into_pix();
-        assert_eq!(s1.0.ct_eq(&s2.0).unwrap_u8(), 1);
-        assert_eq!(p1, p2);
+        let (s1, p1) = kp_1.clone().unzip_into_pix();
+        assert_eq!(s1.0.ct_eq(&kp_1.secret()).unwrap_u8(), 1);
+        assert_eq!(p1, kp_1.public().clone().into());
     }
 }

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -10,7 +10,7 @@ use crate::crypto::{
 /// AES with 128-bit key in counter-mode (with big-endian counter).
 pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
-use crate::crypto::prelude::BjjPublicKey;
+use crate::crypto::prelude::{BjjPublicKey, Keypair, PublicKey};
 use crate::primitive::prelude::{Address, GeneralError};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{
@@ -194,6 +194,12 @@ impl From<Address> for PixDepositAddress {
     }
 }
 
+impl From<PublicKey> for PixDepositAddress {
+    fn from(value: PublicKey) -> Self {
+        Self::Eth(value.to_address())
+    }
+}
+
 impl TryFrom<PixDepositAddress> for Address {
     type Error = GeneralError;
 
@@ -227,3 +233,21 @@ impl TryFrom<PixDepositAddress> for BjjPublicKey {
 /// Usually the [`PixDepositAddress`] can be calculated from the secret.
 #[derive(Clone, Debug)]
 pub struct PixDepositSecret(pub SecretValue<typenum::U32>);
+
+impl AsRef<SecretValue<typenum::U32>> for PixDepositSecret {
+    fn as_ref(&self) -> &SecretValue<typenum::U32> {
+        &self.0
+    }
+}
+
+impl From<PixDepositSecret> for SecretValue<typenum::U32> {
+    fn from(value: PixDepositSecret) -> Self {
+        value.0
+    }
+}
+
+impl From<SecretValue<typenum::U32>> for PixDepositSecret {
+    fn from(value: SecretValue<typenum::U32>) -> Self {
+        Self(value)
+    }
+}

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -10,7 +10,7 @@ use crate::crypto::{
 /// AES with 128-bit key in counter-mode (with big-endian counter).
 pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
-use crate::crypto::prelude::{BjjPublicKey, Keypair, PublicKey};
+use crate::crypto::prelude::{BjjPublicKey, PublicKey};
 use crate::primitive::prelude::{Address, GeneralError};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{


### PR DESCRIPTION
Adds additional helper support and extension trait for PIX keypairs.