### PR TITLE
feat: add PIX session deposit pool types

### DIFF
--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -213,24 +213,41 @@ impl From<&BjjKeypair> for BjjPublicKey {
 
 /// Extension trait for keypairs that can be used as PIX deposit/withdrawal keys.
 ///
-/// This trait is automatically implemented for all keypairs, where the public key is convertible into [`PixDepositAddress`]
-/// and the secret key is sized so that it also fits the [`PixDepositSecret`].
-pub trait PixKeypairExt: Keypair<SecretLen = typenum::U32>
-where
-    <Self as Keypair>::Public: Into<PixDepositAddress>,
-{
+/// Implementations preserve the curve tag required to interpret the secret.
+pub trait PixKeypairExt: Keypair<SecretLen = typenum::U32> {
+    /// Reconstructs this keypair from a curve-compatible PIX secret.
+    fn from_pix_secret(secret: &PixDepositSecret) -> Result<Self, errors::CryptoError>;
+
     /// Consumes the instance and produces corresponding [`PixDepositSecret`] and [`PixDepositAddress`].
+    fn unzip_into_pix(self) -> (PixDepositSecret, PixDepositAddress);
+}
+
+impl PixKeypairExt for ChainKeypair {
+    fn from_pix_secret(secret: &PixDepositSecret) -> Result<Self, errors::CryptoError> {
+        match secret {
+            PixDepositSecret::Eth(secret) => Self::from_secret(secret.as_ref()),
+            PixDepositSecret::Bjj(_) => Err(InvalidInputValue("PIX secret uses BabyJubJub")),
+        }
+    }
+
     fn unzip_into_pix(self) -> (PixDepositSecret, PixDepositAddress) {
         let (secret, public) = self.unzip();
-        (secret.into(), public.into())
+        (PixDepositSecret::Eth(secret), public.into())
     }
 }
 
-impl<K> PixKeypairExt for K
-where
-    K: Keypair<SecretLen = typenum::U32>,
-    <K as Keypair>::Public: Into<PixDepositAddress>,
-{
+impl PixKeypairExt for BjjKeypair {
+    fn from_pix_secret(secret: &PixDepositSecret) -> Result<Self, errors::CryptoError> {
+        match secret {
+            PixDepositSecret::Bjj(secret) => Self::from_secret(secret.as_ref()),
+            PixDepositSecret::Eth(_) => Err(InvalidInputValue("PIX secret uses secp256k1")),
+        }
+    }
+
+    fn unzip_into_pix(self) -> (PixDepositSecret, PixDepositAddress) {
+        let (secret, public) = self.unzip();
+        (PixDepositSecret::Bjj(secret), public.into())
+    }
 }
 
 #[cfg(test)]
@@ -321,7 +338,7 @@ mod tests {
         assert_eq!(p1, p2);
 
         let (s1, p1) = kp_1.clone().unzip_into_pix();
-        assert_eq!(s1.0.ct_eq(&kp_1.secret()).unwrap_u8(), 1);
+        assert_eq!(s1.secret().ct_eq(kp_1.secret()).unwrap_u8(), 1);
         assert_eq!(p1, kp_1.public().clone().into());
     }
 
@@ -365,7 +382,7 @@ mod tests {
         assert_eq!(p1, p2);
 
         let (s1, p1) = kp_1.clone().unzip_into_pix();
-        assert_eq!(s1.0.ct_eq(&kp_1.secret()).unwrap_u8(), 1);
+        assert_eq!(s1.secret().ct_eq(kp_1.secret()).unwrap_u8(), 1);
         assert_eq!(p1, kp_1.public().clone().into());
     }
 }

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Formatter, marker::PhantomData, str::FromStr};
+use std::{fmt::Formatter, marker::PhantomData};
 
 use typenum::Unsigned;
 
@@ -14,7 +14,7 @@ use crate::crypto::{
     errors::CryptoError,
     prelude::{BjjKeypair, BjjPublicKey, Keypair, PublicKey},
 };
-use crate::primitive::prelude::{Address, BytesRepresentable, GeneralError, ToHex};
+use crate::primitive::prelude::{Address, GeneralError};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{
     BabyJubJub, GroupRepr as BabyJubJubCompressedPoint, Scalar as BabyJubJubScalar,
@@ -37,111 +37,6 @@ pub use poly1305::Poly1305;
 /// Keccak-256 and SHA3-256 hash functions, re-exported from the [`sha3`] crate.
 pub use sha3::{Keccak256, Sha3_256};
 use strum::IntoDiscriminant;
-
-const PIX_FIELD_ELEMENT_SIZE: usize = 32;
-
-macro_rules! pix_field_element {
-    ($name:ident, $doc:literal) => {
-        #[doc = $doc]
-        #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        pub struct $name(
-            #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-            [u8; PIX_FIELD_ELEMENT_SIZE],
-        );
-
-        impl AsRef<[u8]> for $name {
-            fn as_ref(&self) -> &[u8] {
-                &self.0
-            }
-        }
-
-        impl TryFrom<&[u8]> for $name {
-            type Error = GeneralError;
-
-            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-                value
-                    .try_into()
-                    .map(Self)
-                    .map_err(|_| GeneralError::ParseError(stringify!($name).into()))
-            }
-        }
-
-        impl BytesRepresentable for $name {
-            const SIZE: usize = PIX_FIELD_ELEMENT_SIZE;
-        }
-
-        impl From<[u8; PIX_FIELD_ELEMENT_SIZE]> for $name {
-            fn from(value: [u8; PIX_FIELD_ELEMENT_SIZE]) -> Self {
-                Self(value)
-            }
-        }
-
-        impl From<$name> for [u8; PIX_FIELD_ELEMENT_SIZE] {
-            fn from(value: $name) -> Self {
-                value.0
-            }
-        }
-
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                f.write_str(&self.to_hex())
-            }
-        }
-
-        impl FromStr for $name {
-            type Err = GeneralError;
-
-            fn from_str(value: &str) -> Result<Self, Self::Err> {
-                Self::from_hex(value)
-            }
-        }
-    };
-}
-
-pix_field_element!(
-    PixNoteId,
-    "A Curvy/PIX note identifier encoded as exactly 32 bytes."
-);
-pix_field_element!(
-    PixNoteTreeRoot,
-    "A root of the Curvy/PIX depth-30 note commitment tree encoded as exactly 32 bytes."
-);
-
-/// Depth of the Curvy note commitment tree.
-pub const PIX_NOTE_TREE_DEPTH: u8 = 30;
-/// Level at which complete Curvy note subtrees are persisted as shards.
-pub const PIX_NOTE_TREE_SHARD_LEVEL: u8 = 14;
-/// Number of dense, non-padding leaves in one completed Curvy note-tree shard.
-pub const PIX_NOTE_TREE_SHARD_SIZE: u64 = 1 << PIX_NOTE_TREE_SHARD_LEVEL;
-
-/// Position of a non-zero note in the dense Curvy note commitment tree.
-///
-/// This is independent from the raw event `item_index`: zero-padded event slots
-/// retain their raw cursor position but do not consume a Merkle leaf position.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PixNoteTreeLeafIndex(pub u64);
-
-/// A pinned view of the indexed Curvy note commitment tree.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PixNoteTreeCheckpoint {
-    /// Root at this checkpoint.
-    pub root: PixNoteTreeRoot,
-    /// Number of dense, non-zero leaves included in `root`.
-    pub leaf_count: u64,
-}
-
-/// Root of one completed level-14 Curvy note-tree shard.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PixNoteTreeShardRoot {
-    /// Zero-based shard index.
-    pub shard_index: u64,
-    /// Root of the 16,384-leaf shard.
-    pub root: PixNoteTreeRoot,
-}
 
 /// Represents a 256-bit secret key of fixed length.
 /// The value is auto-zeroized on drop.
@@ -340,7 +235,8 @@ impl TryFrom<PixDepositAddress> for BjjPublicKey {
 ///
 /// The curve tag is part of the secret so the same 32 bytes cannot accidentally
 /// be interpreted using a different key derivation profile. BabyJubJub scalars
-/// use their canonical little-endian representation; Ethereum scalars use the
+/// use the HOPR canonical big-endian representation; the Curvy adapter converts
+/// them explicitly at its little-endian SDK boundary. Ethereum scalars use the
 /// canonical secp256k1 big-endian representation.
 #[derive(Clone, Debug)]
 pub enum PixDepositSecret {

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Formatter, marker::PhantomData};
+use std::{fmt::Formatter, marker::PhantomData, str::FromStr};
 
 use typenum::Unsigned;
 
@@ -10,8 +10,11 @@ use crate::crypto::{
 /// AES with 128-bit key in counter-mode (with big-endian counter).
 pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
-use crate::crypto::prelude::{BjjPublicKey, PublicKey};
-use crate::primitive::prelude::{Address, GeneralError};
+use crate::crypto::{
+    errors::CryptoError,
+    prelude::{BjjKeypair, BjjPublicKey, Keypair, PublicKey},
+};
+use crate::primitive::prelude::{Address, BytesRepresentable, GeneralError, ToHex};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{
     BabyJubJub, GroupRepr as BabyJubJubCompressedPoint, Scalar as BabyJubJubScalar,
@@ -34,6 +37,111 @@ pub use poly1305::Poly1305;
 /// Keccak-256 and SHA3-256 hash functions, re-exported from the [`sha3`] crate.
 pub use sha3::{Keccak256, Sha3_256};
 use strum::IntoDiscriminant;
+
+const PIX_FIELD_ELEMENT_SIZE: usize = 32;
+
+macro_rules! pix_field_element {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        pub struct $name(
+            #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+            [u8; PIX_FIELD_ELEMENT_SIZE],
+        );
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                &self.0
+            }
+        }
+
+        impl TryFrom<&[u8]> for $name {
+            type Error = GeneralError;
+
+            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+                value
+                    .try_into()
+                    .map(Self)
+                    .map_err(|_| GeneralError::ParseError(stringify!($name).into()))
+            }
+        }
+
+        impl BytesRepresentable for $name {
+            const SIZE: usize = PIX_FIELD_ELEMENT_SIZE;
+        }
+
+        impl From<[u8; PIX_FIELD_ELEMENT_SIZE]> for $name {
+            fn from(value: [u8; PIX_FIELD_ELEMENT_SIZE]) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<$name> for [u8; PIX_FIELD_ELEMENT_SIZE] {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.to_hex())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = GeneralError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::from_hex(value)
+            }
+        }
+    };
+}
+
+pix_field_element!(
+    PixNoteId,
+    "A Curvy/PIX note identifier encoded as exactly 32 bytes."
+);
+pix_field_element!(
+    PixNoteTreeRoot,
+    "A root of the Curvy/PIX depth-30 note commitment tree encoded as exactly 32 bytes."
+);
+
+/// Depth of the Curvy note commitment tree.
+pub const PIX_NOTE_TREE_DEPTH: u8 = 30;
+/// Level at which complete Curvy note subtrees are persisted as shards.
+pub const PIX_NOTE_TREE_SHARD_LEVEL: u8 = 14;
+/// Number of dense, non-padding leaves in one completed Curvy note-tree shard.
+pub const PIX_NOTE_TREE_SHARD_SIZE: u64 = 1 << PIX_NOTE_TREE_SHARD_LEVEL;
+
+/// Position of a non-zero note in the dense Curvy note commitment tree.
+///
+/// This is independent from the raw event `item_index`: zero-padded event slots
+/// retain their raw cursor position but do not consume a Merkle leaf position.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PixNoteTreeLeafIndex(pub u64);
+
+/// A pinned view of the indexed Curvy note commitment tree.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PixNoteTreeCheckpoint {
+    /// Root at this checkpoint.
+    pub root: PixNoteTreeRoot,
+    /// Number of dense, non-zero leaves included in `root`.
+    pub leaf_count: u64,
+}
+
+/// Root of one completed level-14 Curvy note-tree shard.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PixNoteTreeShardRoot {
+    /// Zero-based shard index.
+    pub shard_index: u64,
+    /// Root of the 16,384-leaf shard.
+    pub root: PixNoteTreeRoot,
+}
 
 /// Represents a 256-bit secret key of fixed length.
 /// The value is auto-zeroized on drop.
@@ -230,24 +338,108 @@ impl TryFrom<PixDepositAddress> for BjjPublicKey {
 
 /// A secret corresponding to a PIX deposit address.
 ///
-/// Usually the [`PixDepositAddress`] can be calculated from the secret.
+/// The curve tag is part of the secret so the same 32 bytes cannot accidentally
+/// be interpreted using a different key derivation profile. BabyJubJub scalars
+/// use their canonical little-endian representation; Ethereum scalars use the
+/// canonical secp256k1 big-endian representation.
 #[derive(Clone, Debug)]
-pub struct PixDepositSecret(pub SecretValue<typenum::U32>);
+pub enum PixDepositSecret {
+    /// Secret scalar for an Ethereum PIX deposit address.
+    Eth(SecretKey),
+    /// Secret scalar for a BabyJubJub PIX deposit address.
+    Bjj(SecretKey),
+}
 
-impl AsRef<SecretValue<typenum::U32>> for PixDepositSecret {
-    fn as_ref(&self) -> &SecretValue<typenum::U32> {
-        &self.0
+impl PixDepositSecret {
+    /// Constructs and validates an Ethereum PIX deposit secret.
+    pub fn ethereum(secret: SecretKey) -> Result<Self, CryptoError> {
+        PublicKey::from_privkey(secret.as_ref())?;
+        Ok(Self::Eth(secret))
+    }
+
+    /// Constructs and validates a canonical BabyJubJub PIX deposit secret.
+    pub fn baby_jubjub(secret: SecretKey) -> Result<Self, CryptoError> {
+        BjjPublicKey::from_privkey(secret.as_ref())?;
+        Ok(Self::Bjj(secret))
+    }
+
+    /// Returns the public PIX deposit address corresponding to this secret.
+    pub fn address(&self) -> Result<PixDepositAddress, CryptoError> {
+        match self {
+            Self::Eth(secret) => Ok(PublicKey::from_privkey(secret.as_ref())?
+                .to_address()
+                .into()),
+            Self::Bjj(secret) => Ok(BjjPublicKey::from_privkey(secret.as_ref())?.into()),
+        }
+    }
+
+    /// Returns the address representation accepted by this secret.
+    pub fn address_type(&self) -> PixDepositAddressDiscriminants {
+        match self {
+            Self::Eth(_) => PixDepositAddressDiscriminants::Eth,
+            Self::Bjj(_) => PixDepositAddressDiscriminants::Bjj,
+        }
+    }
+
+    /// Returns the canonical scalar bytes without removing the curve tag.
+    pub fn secret(&self) -> &SecretKey {
+        match self {
+            Self::Eth(secret) | Self::Bjj(secret) => secret,
+        }
     }
 }
 
-impl From<PixDepositSecret> for SecretValue<typenum::U32> {
-    fn from(value: PixDepositSecret) -> Self {
-        value.0
+impl TryFrom<&PixDepositSecret> for PixDepositAddress {
+    type Error = CryptoError;
+
+    fn try_from(value: &PixDepositSecret) -> Result<Self, Self::Error> {
+        value.address()
     }
 }
 
-impl From<SecretValue<typenum::U32>> for PixDepositSecret {
-    fn from(value: SecretValue<typenum::U32>) -> Self {
-        Self(value)
+/// Converts the validated BabyJubJub keypair reconstructed by the PIX protocol
+/// into the curve-tagged secret consumed by a deposit-pool implementation.
+impl From<&BjjKeypair> for PixDepositSecret {
+    fn from(value: &BjjKeypair) -> Self {
+        Self::Bjj(value.secret().clone())
+    }
+}
+
+#[cfg(test)]
+mod pix_tests {
+    use super::*;
+
+    #[test]
+    fn pix_secrets_are_curve_tagged_and_derive_their_addresses() -> anyhow::Result<()> {
+        let scalar = SecretKey::from([1_u8; 32]);
+        let bjj = PixDepositSecret::baby_jubjub(scalar.clone())?;
+        let eth = PixDepositSecret::ethereum(scalar)?;
+
+        assert_eq!(bjj.address_type(), PixDepositAddressDiscriminants::Bjj);
+        assert!(matches!(bjj.address()?, PixDepositAddress::Bjj(_)));
+        assert_eq!(eth.address_type(), PixDepositAddressDiscriminants::Eth);
+        assert!(matches!(eth.address()?, PixDepositAddress::Eth(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn pix_secret_constructors_reject_invalid_scalars() {
+        let zero = SecretKey::from([0_u8; 32]);
+
+        assert!(PixDepositSecret::baby_jubjub(zero.clone()).is_err());
+        assert!(PixDepositSecret::ethereum(zero).is_err());
+    }
+
+    #[test]
+    fn reconstructed_bjj_keypair_becomes_a_tagged_pix_secret() -> anyhow::Result<()> {
+        let reconstructed = BjjKeypair::random();
+        let secret = PixDepositSecret::from(&reconstructed);
+
+        assert_eq!(
+            secret.address()?,
+            PixDepositAddress::from(*reconstructed.public())
+        );
+        assert_eq!(secret.address_type(), PixDepositAddressDiscriminants::Bjj);
+        Ok(())
     }
 }

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -597,6 +597,16 @@ impl BjjPublicKey {
         let point = babyjubjub_ec::ProjectivePoint::GENERATOR * scalar;
         point.try_into()
     }
+
+    /// Returns the affine point coordinates as canonical decimal strings.
+    ///
+    /// This is the lossless boundary representation used by BabyJubJub systems
+    /// whose field implementation differs from the one used by `hopr-types`.
+    pub fn to_decimal_coordinates(&self) -> (String, String) {
+        let point: babyjubjub_ec::ProjectivePoint = self.into();
+        let affine = point.to_affine();
+        (affine.x().to_string(), affine.y().to_string())
+    }
 }
 
 impl Display for BjjPublicKey {

--- a/src/network/session.rs
+++ b/src/network/session.rs
@@ -1,9 +1,84 @@
 //! Types describing HOPR Sessions and their targets.
 
+use std::num::NonZeroU32;
+
+use crate::primitive::prelude::{BytesRepresentable, GeneralError};
+
 use super::types::SealedHost;
 
 /// Identity of a HOPR Session.
 pub type SessionId = crate::internal::protocol::HoprPseudonym;
+
+/// Identifies one PIX deposit allocation within a HOPR Session.
+///
+/// A session may create several deposit addresses, so the session identifier
+/// alone is not sufficient as a durable allocation key.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PixAddressId {
+    session_id: SessionId,
+    allocation_index: NonZeroU32,
+}
+
+impl PixAddressId {
+    /// Encoded size: session pseudonym followed by a big-endian allocation index.
+    pub const SIZE: usize = SessionId::SIZE + size_of::<u32>();
+
+    /// Creates a PIX allocation identifier.
+    pub const fn new(session_id: SessionId, allocation_index: NonZeroU32) -> Self {
+        Self {
+            session_id,
+            allocation_index,
+        }
+    }
+
+    /// Returns the HOPR Session to which this allocation belongs.
+    pub const fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    /// Returns the non-zero allocation index within the session.
+    pub const fn allocation_index(&self) -> NonZeroU32 {
+        self.allocation_index
+    }
+
+    /// Returns the stable database-key representation.
+    pub fn to_bytes(self) -> [u8; Self::SIZE] {
+        let mut bytes = [0_u8; Self::SIZE];
+        bytes[..SessionId::SIZE].copy_from_slice(self.session_id.as_ref());
+        bytes[SessionId::SIZE..].copy_from_slice(&self.allocation_index.get().to_be_bytes());
+        bytes
+    }
+}
+
+impl TryFrom<&[u8]> for PixAddressId {
+    type Error = GeneralError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != Self::SIZE {
+            return Err(GeneralError::ParseError("PixAddressId".into()));
+        }
+        let session_id = SessionId::try_from(&value[..SessionId::SIZE])?;
+        let index_bytes: [u8; size_of::<u32>()] = value[SessionId::SIZE..]
+            .try_into()
+            .map_err(|_| GeneralError::ParseError("PixAddressId allocation index".into()))?;
+        let allocation_index = NonZeroU32::new(u32::from_be_bytes(index_bytes))
+            .ok_or_else(|| GeneralError::ParseError("PixAddressId allocation index".into()))?;
+        Ok(Self::new(session_id, allocation_index))
+    }
+}
+
+impl From<PixAddressId> for (SessionId, NonZeroU32) {
+    fn from(value: PixAddressId) -> Self {
+        (value.session_id, value.allocation_index)
+    }
+}
+
+impl From<(SessionId, NonZeroU32)> for PixAddressId {
+    fn from((session_id, allocation_index): (SessionId, NonZeroU32)) -> Self {
+        Self::new(session_id, allocation_index)
+    }
+}
 
 /// Identifies a node-local service target.
 ///
@@ -24,4 +99,30 @@ pub enum SessionTarget {
     TcpStream(SealedHost),
     /// Target is a service directly at the exit node with the given service ID.
     ExitNode(ServiceId),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pix_address_id_has_a_stable_roundtrip_encoding() -> anyhow::Result<()> {
+        let session_id = SessionId::from([7_u8; SessionId::SIZE]);
+        let allocation_index =
+            NonZeroU32::new(3).ok_or_else(|| anyhow::anyhow!("index must be non-zero"))?;
+        let id = PixAddressId::new(session_id, allocation_index);
+
+        assert_eq!(PixAddressId::try_from(id.to_bytes().as_slice())?, id);
+        assert_eq!(id.session_id(), session_id);
+        assert_eq!(id.allocation_index(), allocation_index);
+        Ok(())
+    }
+
+    #[test]
+    fn pix_address_id_rejects_a_zero_allocation_index() {
+        let mut bytes = [0_u8; PixAddressId::SIZE];
+        bytes[..SessionId::SIZE].copy_from_slice(SessionId::from([7_u8; SessionId::SIZE]).as_ref());
+
+        assert!(PixAddressId::try_from(bytes.as_slice()).is_err());
+    }
 }

--- a/src/network/session.rs
+++ b/src/network/session.rs
@@ -14,10 +14,30 @@ pub type SessionId = crate::internal::protocol::HoprPseudonym;
 /// A session may create several deposit addresses, so the session identifier
 /// alone is not sufficient as a durable allocation key.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixAddressId {
     session_id: SessionId,
     allocation_index: NonZeroU32,
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PixAddressId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(&self.to_bytes())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PixAddressId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = <serde_bytes::ByteBuf as serde::Deserialize>::deserialize(deserializer)?;
+        Self::try_from(bytes.as_ref()).map_err(serde::de::Error::custom)
+    }
 }
 
 impl PixAddressId {
@@ -124,5 +144,19 @@ mod tests {
         bytes[..SessionId::SIZE].copy_from_slice(SessionId::from([7_u8; SessionId::SIZE]).as_ref());
 
         assert!(PixAddressId::try_from(bytes.as_slice()).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn pix_address_id_serde_uses_the_stable_byte_encoding() -> anyhow::Result<()> {
+        let id = PixAddressId::new(
+            SessionId::from([7_u8; SessionId::SIZE]),
+            NonZeroU32::new(3).ok_or_else(|| anyhow::anyhow!("index must be non-zero"))?,
+        );
+
+        let encoded = serde_json::to_vec(&id)?;
+        assert_eq!(serde_json::from_slice::<PixAddressId>(&encoded)?, id);
+        assert_eq!(serde_json::from_slice::<Vec<u8>>(&encoded)?, id.to_bytes());
+        Ok(())
     }
 }


### PR DESCRIPTION
Add the core types required to model PIX session deposit allocations and note-tree state.

- add curve-tagged `PixDepositSecret` variants for Ethereum and BabyJubJub keys
- validate PIX secrets and derive their corresponding deposit addresses
- support reconstructing compatible keypairs from tagged PIX secrets
- add PIX note IDs, tree roots, checkpoints, shard roots, and tree constants
- add `PixAddressId` for stable session-scoped deposit allocation identifiers
- expose BabyJubJub public-key coordinates as canonical decimal strings
- add tests for secret validation, address derivation, and identifier encoding
