### PR TITLE
chore: bump hopr-bindings post piz-palu and jura renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.1"
+version = "4.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
+checksum = "8be6fd9b90421c230f80c6ba872cd02c65cfd5e84cdb99956edbd8a6dac6334c"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ const-hex = { version = "1.19.1", optional = true, default-features = false, fea
 ] }
 hash2curve = { version = "0.14.0", optional = true }
 hex-literal = { version = "1.1.0", optional = true }
-hopr-bindings = { version = "4.12.1", optional = true }
+hopr-bindings = { version = "4.13.0", optional = true }
 k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
@@ -211,7 +211,7 @@ uuid = { version = "1.24.0", optional = true, features = ["serde", "v4"] }
 zeroize = { version = "1.9.0", optional = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
-hopr-bindings = "4.9.1"
+hopr-bindings = "4.13.0"
 anyhow = "1.0.102"
 bimap = "0.6.3"
 criterion = "0.8.2"


### PR DESCRIPTION
### Description

Bump dependency `hopr-bindings` to `v4.13.0` (inclu. piz-palu and jura renaming)