### PR TITLE
feat: add service registry types and chain events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,9 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
+version = "4.12.2"
+source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "4.14.0"
-source = "git+https://github.com/hoprnet/contracts?rev=0eea1981c67343e65ff4e5ecb0b81b9ddc201b14#0eea1981c67343e65ff4e5ecb0b81b9ddc201b14"
+source = "git+https://github.com/hoprnet/contracts?rev=ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c#ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,8 +2762,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.2"
-source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
+version = "4.14.0"
+source = "git+https://github.com/hoprnet/contracts?rev=0eea1981c67343e65ff4e5ecb0b81b9ddc201b14#0eea1981c67343e65ff4e5ecb0b81b9ddc201b14"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ hash2curve = { version = "0.14.0", optional = true }
 hex-literal = { version = "1.1.0", optional = true }
 # TODO: revert to a crates.io version once contracts publishes a release containing
 # HoprServiceRegistry (local version 4.12.2). Keep in sync with the dev-dependency below.
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3", optional = true }
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14", optional = true }
 k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
@@ -223,7 +223,7 @@ zeroize = { version = "1.9.0", optional = true, features = ["zeroize_derive"] }
 [dev-dependencies]
 # TODO: revert to a crates.io version once contracts publishes a release containing
 # HoprServiceRegistry. Must resolve to the same source as the dependency above.
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3" }
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14" }
 anyhow = "1.0.102"
 bimap = "0.6.3"
 criterion = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,9 @@ const-hex = { version = "1.19.1", optional = true, default-features = false, fea
 ] }
 hash2curve = { version = "0.14.0", optional = true }
 hex-literal = { version = "1.1.0", optional = true }
-hopr-bindings = { version = "4.12.1", optional = true }
+# TODO: revert to a crates.io version once contracts publishes a release containing
+# HoprServiceRegistry (local version 4.12.2). Keep in sync with the dev-dependency below.
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3", optional = true }
 k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
@@ -211,7 +213,9 @@ uuid = { version = "1.24.0", optional = true, features = ["serde", "v4"] }
 zeroize = { version = "1.9.0", optional = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
-hopr-bindings = "4.9.1"
+# TODO: revert to a crates.io version once contracts publishes a release containing
+# HoprServiceRegistry. Must resolve to the same source as the dependency above.
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3" }
 anyhow = "1.0.102"
 bimap = "0.6.3"
 criterion = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ hash2curve = { version = "0.14.0", optional = true }
 hex-literal = { version = "1.1.0", optional = true }
 # TODO: revert to a crates.io version once contracts publishes a release containing
 # HoprServiceRegistry (local version 4.12.2). Keep in sync with the dev-dependency below.
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14", optional = true }
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c", optional = true }
 k256 = { version = "0.14.0", optional = true, features = [
   "arithmetic",
   "ecdh",
@@ -223,7 +223,7 @@ zeroize = { version = "1.9.0", optional = true, features = ["zeroize_derive"] }
 [dev-dependencies]
 # TODO: revert to a crates.io version once contracts publishes a release containing
 # HoprServiceRegistry. Must resolve to the same source as the dependency above.
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14" }
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c" }
 anyhow = "1.0.102"
 bimap = "0.6.3"
 criterion = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-types"
-version = "2.2.1"
+version = "2.3.0"
 description = "Complete collection of Rust types used in Hoprnet and other related projects"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/chain/chain_events.rs
+++ b/src/chain/chain_events.rs
@@ -50,6 +50,50 @@ pub enum ChainEvent {
 
     /// A new ticket price has been set.
     TicketPriceChanged(HoprBalance),
+
+    /// A node registered an entry in the service registry.
+    ///
+    /// The [`ServiceEntry`] has its `updated_at` equal to its `registered_at`, because
+    /// registration is also the first update.
+    ServiceRegistered(ServiceEntry),
+
+    /// A node replaced the metadata of one of its service registry entries.
+    ///
+    /// The originating event does not carry the registration timestamp, so `registered_at` on
+    /// the [`ServiceEntry`] mirrors `updated_at`. Consumers holding the previous state of the
+    /// entry should keep their own `registered_at`.
+    ServiceUpdated(ServiceEntry),
+
+    /// A node removed one of its service registry entries.
+    ///
+    /// Carries the service type and the node the entry belonged to.
+    ServiceDeregistered(ServiceType, Address),
+
+    /// A new service type exists, owned by the given address.
+    ServiceTypeRegistered(ServiceType, Address),
+
+    /// Ownership of a service type moved to another address.
+    ///
+    /// `None` means the type was abandoned, which is one-way: an abandoned type keeps its
+    /// configuration forever.
+    ServiceTypeOwnerChanged(ServiceType, Option<Address>),
+
+    /// The requirement contract gating registrations under a service type has changed.
+    ///
+    /// `None` means the type is open, with no policy beyond the Safe binding and the burn.
+    ServiceTypeRequirementChanged(ServiceType, Option<Address>),
+
+    /// The amount burned when registering an entry under a service type has changed.
+    ServiceTypeRegistrationBurnChanged(ServiceType, HoprBalance),
+
+    /// The amount burned when updating an entry under a service type has changed.
+    ServiceTypeUpdateBurnChanged(ServiceType, HoprBalance),
+
+    /// The global fee burned when registering a new service type has changed.
+    ServiceTypeRegistrationFeeChanged(HoprBalance),
+
+    /// The service registry now reads node-to-Safe bindings from a different registry contract.
+    ServiceRegistryPointerChanged(Address),
 }
 
 impl Display for ChainEvent {
@@ -77,6 +121,171 @@ impl Display for ChainEvent {
                 write!(f, "winning probability decreased to {p}")
             }
             ChainEvent::TicketPriceChanged(p) => write!(f, "ticket price changed to {p}"),
+            ChainEvent::ServiceRegistered(e) => write!(f, "service registration event of {e}"),
+            ChainEvent::ServiceUpdated(e) => write!(f, "service update event of {e}"),
+            ChainEvent::ServiceDeregistered(t, node) => {
+                write!(f, "service deregistration event of {t} for node {node}")
+            }
+            ChainEvent::ServiceTypeRegistered(t, owner) => {
+                write!(f, "service type {t} registered by {owner}")
+            }
+            ChainEvent::ServiceTypeOwnerChanged(t, Some(owner)) => {
+                write!(f, "service type {t} owner changed to {owner}")
+            }
+            ChainEvent::ServiceTypeOwnerChanged(t, None) => {
+                write!(f, "service type {t} abandoned")
+            }
+            ChainEvent::ServiceTypeRequirementChanged(t, Some(req)) => {
+                write!(f, "service type {t} requirement changed to {req}")
+            }
+            ChainEvent::ServiceTypeRequirementChanged(t, None) => {
+                write!(f, "service type {t} requirement removed")
+            }
+            ChainEvent::ServiceTypeRegistrationBurnChanged(t, a) => {
+                write!(f, "service type {t} registration burn changed to {a}")
+            }
+            ChainEvent::ServiceTypeUpdateBurnChanged(t, a) => {
+                write!(f, "service type {t} update burn changed to {a}")
+            }
+            ChainEvent::ServiceTypeRegistrationFeeChanged(a) => {
+                write!(f, "service type registration fee changed to {a}")
+            }
+            ChainEvent::ServiceRegistryPointerChanged(a) => {
+                write!(f, "service registry node safe registry changed to {a}")
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use hex_literal::hex;
+
+    use super::*;
+
+    const NODE: [u8; 20] = hex!("2cDD13ddB0346E0F620C8E5826Da5d7230341c6E");
+    const OWNER: [u8; 20] = hex!("42e0e02c7b7c46ec3d5b8c3fdb2f2e3f2a4b5c6d");
+
+    fn service_entry() -> anyhow::Result<ServiceEntry> {
+        Ok(ServiceEntry::new(
+            ServiceType::GVPN_EXIT,
+            Address::from(NODE),
+            Address::from(OWNER),
+            ServiceMetadata::try_from(b"exit-node".to_vec())?,
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            UNIX_EPOCH + Duration::from_secs(1_700_000_060),
+        )?)
+    }
+
+    #[test]
+    fn service_entry_events_display_and_expose_accessors() -> anyhow::Result<()> {
+        let entry = service_entry()?;
+
+        let registered = ChainEvent::ServiceRegistered(entry.clone());
+        assert_eq!(
+            format!("service registration event of {entry}"),
+            registered.to_string()
+        );
+        assert!(registered.is_service_registered());
+        assert!(!registered.is_service_updated());
+        assert_eq!(
+            Some(entry.clone()),
+            registered.clone().try_as_service_registered()
+        );
+        assert_eq!(None, registered.try_as_service_updated());
+
+        let updated = ChainEvent::ServiceUpdated(entry.clone());
+        assert_eq!(
+            format!("service update event of {entry}"),
+            updated.to_string()
+        );
+        assert!(updated.is_service_updated());
+        assert_eq!(Some(entry), updated.try_as_service_updated());
+
+        let deregistered =
+            ChainEvent::ServiceDeregistered(ServiceType::GVPN_EXIT, Address::from(NODE));
+        assert_eq!(
+            "service deregistration event of gvpn:exit for node 0x2cdd13ddb0346e0f620c8e5826da5d7230341c6e",
+            deregistered.to_string()
+        );
+        assert!(deregistered.is_service_deregistered());
+        assert_eq!(
+            Some((ServiceType::GVPN_EXIT, Address::from(NODE))),
+            deregistered.try_as_service_deregistered()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_events_display_and_expose_accessors() {
+        let owner = Address::from(OWNER);
+
+        let registered = ChainEvent::ServiceTypeRegistered(ServiceType::GVPN_EXIT, owner);
+        assert_eq!(
+            format!("service type gvpn:exit registered by {owner}"),
+            registered.to_string()
+        );
+        assert!(registered.is_service_type_registered());
+        assert_eq!(
+            Some((ServiceType::GVPN_EXIT, owner)),
+            registered.try_as_service_type_registered()
+        );
+
+        assert_eq!(
+            format!("service type gvpn:exit owner changed to {owner}"),
+            ChainEvent::ServiceTypeOwnerChanged(ServiceType::GVPN_EXIT, Some(owner)).to_string()
+        );
+        assert_eq!(
+            "service type gvpn:exit abandoned",
+            ChainEvent::ServiceTypeOwnerChanged(ServiceType::GVPN_EXIT, None).to_string()
+        );
+
+        assert_eq!(
+            format!("service type gvpn:exit requirement changed to {owner}"),
+            ChainEvent::ServiceTypeRequirementChanged(ServiceType::GVPN_EXIT, Some(owner))
+                .to_string()
+        );
+        assert_eq!(
+            "service type gvpn:exit requirement removed",
+            ChainEvent::ServiceTypeRequirementChanged(ServiceType::GVPN_EXIT, None).to_string()
+        );
+    }
+
+    #[test]
+    fn service_configuration_events_display_and_expose_accessors() -> anyhow::Result<()> {
+        let amount: HoprBalance = "10 wxHOPR".parse()?;
+
+        assert_eq!(
+            format!("service type gvpn:exit registration burn changed to {amount}"),
+            ChainEvent::ServiceTypeRegistrationBurnChanged(ServiceType::GVPN_EXIT, amount)
+                .to_string()
+        );
+        assert_eq!(
+            format!("service type gvpn:exit update burn changed to {amount}"),
+            ChainEvent::ServiceTypeUpdateBurnChanged(ServiceType::GVPN_EXIT, amount).to_string()
+        );
+
+        let fee_changed = ChainEvent::ServiceTypeRegistrationFeeChanged(amount);
+        assert_eq!(
+            format!("service type registration fee changed to {amount}"),
+            fee_changed.to_string()
+        );
+        assert_eq!(
+            Some(amount),
+            fee_changed.try_as_service_type_registration_fee_changed()
+        );
+
+        let pointer = Address::from(OWNER);
+        let pointer_changed = ChainEvent::ServiceRegistryPointerChanged(pointer);
+        assert_eq!(
+            format!("service registry node safe registry changed to {pointer}"),
+            pointer_changed.to_string()
+        );
+        assert!(pointer_changed.is_service_registry_pointer_changed());
+
+        Ok(())
     }
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -43,6 +43,11 @@ pub struct ContractAddresses {
     /// Safe registry contract
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub node_safe_registry: crate::primitive::primitives::Address,
+    /// Service registry contract.
+    ///
+    /// A network that has no deployment yet carries the zero address here.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub service_registry: crate::primitive::primitives::Address,
     /// Price oracle contract
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub ticket_price_oracle: crate::primitive::primitives::Address,
@@ -71,6 +76,7 @@ impl IntoIterator for &ContractAddresses {
             self.channels,
             self.announcements,
             self.node_safe_registry,
+            self.service_registry,
             self.ticket_price_oracle,
             self.winning_probability_oracle,
             self.node_stake_factory,
@@ -98,4 +104,46 @@ pub fn contract_addresses_for_network(name: &str) -> Option<(u64, ContractAddres
 #[inline]
 pub(in crate::chain) fn a2al(a: crate::primitive::prelude::Address) -> AlloyAddress {
     AlloyAddress::from_slice(a.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain::payload::tests::CONTRACT_ADDRS_JSON;
+
+    /// The `service_registry` entry of [`CONTRACT_ADDRS_JSON`], lowercased.
+    ///
+    /// The two `ContractAddresses` structs - the hand-written one and the one re-exported from
+    /// the bindings - print addresses differently (lowercase hex versus EIP-55 checksum), so
+    /// these tests compare lowercased strings and stay valid under both feature sets.
+    const SERVICE_REGISTRY: &str = "0x9a676e781a523b5d0c0e43731313a708cb607508";
+
+    #[test]
+    fn contract_addresses_round_trip_the_service_registry_through_json() -> anyhow::Result<()> {
+        let addresses: ContractAddresses = serde_json::from_str(CONTRACT_ADDRS_JSON)?;
+
+        assert_eq!(
+            SERVICE_REGISTRY,
+            addresses.service_registry.to_string().to_lowercase()
+        );
+
+        let reparsed: ContractAddresses =
+            serde_json::from_str(&serde_json::to_string(&addresses)?)?;
+        assert_eq!(addresses, reparsed);
+
+        Ok(())
+    }
+
+    #[test]
+    fn contract_addresses_iterate_over_the_service_registry() -> anyhow::Result<()> {
+        let addresses: ContractAddresses = serde_json::from_str(CONTRACT_ADDRS_JSON)?;
+
+        assert!(
+            (&addresses)
+                .into_iter()
+                .any(|address| address.to_string().to_lowercase() == SERVICE_REGISTRY)
+        );
+
+        Ok(())
+    }
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -79,6 +79,7 @@ impl IntoIterator for &ContractAddresses {
             self.service_registry,
             self.ticket_price_oracle,
             self.winning_probability_oracle,
+            self.node_safe_migration,
             self.node_stake_factory,
             self.module_implementation,
         ]

--- a/src/chain/payload/bindings_based.rs
+++ b/src/chain/payload/bindings_based.rs
@@ -34,6 +34,9 @@ use hopr_bindings::{
     hopr_node_safe_registry::HoprNodeSafeRegistry::{
         deregisterNodeBySafeCall, registerSafeByNodeCall,
     },
+    hopr_service_registry::HoprServiceRegistry::{
+        selfDeregisterCall, selfRegisterCall, selfUpdateCall,
+    },
     hopr_token::HoprToken::{approveCall, sendCall, transferCall},
 };
 
@@ -82,8 +85,15 @@ sol! (
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Operation {
     Call = 0,
-    // Future use: DelegateCall = 1,
+    DelegateCall = 1,
 }
+
+sol! {
+    function multiSend(bytes transactions);
+}
+
+const SAFE_MULTI_SEND_ADDRESS: alloy::primitives::Address =
+    alloy::primitives::address!("38869bf66a61cF6bDB996A6aE40D5853Fd43B526");
 
 #[async_trait::async_trait]
 impl SignableTransaction for TransactionRequest {
@@ -157,6 +167,75 @@ fn register_safe_tx(safe_addr: Address) -> TransactionRequest {
         }
         .abi_encode(),
     )
+}
+
+fn encode_multi_send_transaction(to: alloy::primitives::Address, data: &[u8]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(85 + data.len());
+    encoded.push(Operation::Call as u8);
+    encoded.extend_from_slice(to.as_slice());
+    encoded.extend_from_slice(&[0u8; 32]);
+    encoded.extend_from_slice(&U256::from(data.len()).to_be_bytes::<32>());
+    encoded.extend_from_slice(data);
+    encoded
+}
+
+fn service_registry_call(
+    service_type: ServiceType,
+    node: Address,
+    metadata: Option<&ServiceMetadata>,
+    update: bool,
+) -> Vec<u8> {
+    let service_type = B256::from(service_type.as_encoded());
+    let node = a2al(node);
+    match metadata {
+        Some(metadata) if update => selfUpdateCall {
+            serviceType: service_type,
+            node,
+            metadata: metadata.as_ref().to_vec().into(),
+        }
+        .abi_encode(),
+        Some(metadata) => selfRegisterCall {
+            serviceType: service_type,
+            node,
+            metadata: metadata.as_ref().to_vec().into(),
+        }
+        .abi_encode(),
+        None => selfDeregisterCall {
+            serviceType: service_type,
+            node,
+        }
+        .abi_encode(),
+    }
+}
+
+fn paid_service_registry_payload(
+    token: alloy::primitives::Address,
+    registry: alloy::primitives::Address,
+    registry_call: &[u8],
+    burn: HoprBalance,
+) -> Vec<u8> {
+    let mut transactions = Vec::new();
+    if !burn.is_zero() {
+        let approval = approveCall {
+            spender: registry,
+            value: U256::from_be_bytes(burn.amount().to_be_bytes()),
+        }
+        .abi_encode();
+        transactions.extend_from_slice(&encode_multi_send_transaction(token, &approval));
+    }
+    transactions.extend_from_slice(&encode_multi_send_transaction(registry, registry_call));
+
+    let multi_send = multiSendCall {
+        transactions: transactions.into(),
+    }
+    .abi_encode();
+    execTransactionFromModuleCall {
+        to: SAFE_MULTI_SEND_ADDRESS,
+        value: U256::ZERO,
+        data: multi_send.into(),
+        operation: Operation::DelegateCall as u8,
+    }
+    .abi_encode()
 }
 
 /// Generates transaction payloads that do not use Safe-compliant ABI
@@ -333,6 +412,54 @@ impl PayloadGenerator for BasicPayloadGenerator {
         Err(InvalidState(
             "Can only deregister an address if Safe is activated",
         ))
+    }
+
+    fn register_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        registration_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        if !registration_burn.is_zero() {
+            return Err(InvalidState(
+                "paid service writes require a Safe payload generator",
+            ));
+        }
+        Ok(TransactionRequest::default()
+            .with_input(service_registry_call(
+                service_type,
+                self.me,
+                Some(&metadata),
+                false,
+            ))
+            .with_to(self.contract_addrs.service_registry))
+    }
+
+    fn update_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        update_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        if !update_burn.is_zero() {
+            return Err(InvalidState(
+                "paid service writes require a Safe payload generator",
+            ));
+        }
+        Ok(TransactionRequest::default()
+            .with_input(service_registry_call(
+                service_type,
+                self.me,
+                Some(&metadata),
+                true,
+            ))
+            .with_to(self.contract_addrs.service_registry))
+    }
+
+    fn deregister_service(&self, service_type: ServiceType) -> payload::Result<Self::TxRequest> {
+        Ok(TransactionRequest::default()
+            .with_input(service_registry_call(service_type, self.me, None, false))
+            .with_to(self.contract_addrs.service_registry))
     }
 
     fn deploy_safe(
@@ -626,6 +753,58 @@ impl PayloadGenerator for SafePayloadGenerator {
             .with_gas_limit(DEFAULT_TX_GAS);
 
         Ok(tx)
+    }
+
+    fn register_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        registration_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        let call = service_registry_call(service_type, self.me, Some(&metadata), false);
+        Ok(TransactionRequest::default()
+            .with_input(paid_service_registry_payload(
+                self.contract_addrs.token,
+                self.contract_addrs.service_registry,
+                &call,
+                registration_burn,
+            ))
+            .with_to(a2al(self.module))
+            .with_gas_limit(DEFAULT_TX_GAS))
+    }
+
+    fn update_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        update_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        let call = service_registry_call(service_type, self.me, Some(&metadata), true);
+        Ok(TransactionRequest::default()
+            .with_input(paid_service_registry_payload(
+                self.contract_addrs.token,
+                self.contract_addrs.service_registry,
+                &call,
+                update_burn,
+            ))
+            .with_to(a2al(self.module))
+            .with_gas_limit(DEFAULT_TX_GAS))
+    }
+
+    fn deregister_service(&self, service_type: ServiceType) -> payload::Result<Self::TxRequest> {
+        let call = service_registry_call(service_type, self.me, None, false);
+        Ok(TransactionRequest::default()
+            .with_input(
+                execTransactionFromModuleCall {
+                    to: self.contract_addrs.service_registry,
+                    value: U256::ZERO,
+                    data: call.into(),
+                    operation: Operation::Call as u8,
+                }
+                .abi_encode(),
+            )
+            .with_to(a2al(self.module))
+            .with_gas_limit(DEFAULT_TX_GAS))
     }
 
     fn deploy_safe(

--- a/src/chain/payload/cross_verify.rs
+++ b/src/chain/payload/cross_verify.rs
@@ -496,3 +496,76 @@ async fn deregister_node_by_safe() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn register_service_safe_with_burn() -> anyhow::Result<()> {
+    let key = ChainKeypair::from_secret(&PRIVATE_KEY_1)?;
+    let service_type = ServiceType::from_str("gvpn:exit")?;
+    let metadata = ServiceMetadata::try_from(br#"{\"endpoint\":\"1.2.3.4:443\"}"#.to_vec())?;
+    let (b_gen, s_gen) = safe_gens(&key);
+
+    assert_signed_eq!(
+        "register_service_safe_with_burn",
+        b_gen.register_service(service_type, metadata.clone(), HoprBalance::from(100))?,
+        s_gen.register_service(service_type, metadata, HoprBalance::from(100))?,
+        19,
+        1,
+        &key
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_service_safe_without_burn() -> anyhow::Result<()> {
+    let key = ChainKeypair::from_secret(&PRIVATE_KEY_1)?;
+    let service_type = ServiceType::from_str("gvpn:exit")?;
+    let metadata = ServiceMetadata::try_from(b"updated".to_vec())?;
+    let (b_gen, s_gen) = safe_gens(&key);
+
+    assert_signed_eq!(
+        "update_service_safe_without_burn",
+        b_gen.update_service(service_type, metadata.clone(), HoprBalance::zero())?,
+        s_gen.update_service(service_type, metadata, HoprBalance::zero())?,
+        20,
+        1,
+        &key
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn deregister_service_safe() -> anyhow::Result<()> {
+    let key = ChainKeypair::from_secret(&PRIVATE_KEY_1)?;
+    let service_type = ServiceType::from_str("gvpn:exit")?;
+    let (b_gen, s_gen) = safe_gens(&key);
+
+    assert_signed_eq!(
+        "deregister_service_safe",
+        b_gen.deregister_service(service_type)?,
+        s_gen.deregister_service(service_type)?,
+        21,
+        1,
+        &key
+    );
+    Ok(())
+}
+
+#[test]
+fn paid_service_write_requires_safe_generator() -> anyhow::Result<()> {
+    let key = ChainKeypair::from_secret(&PRIVATE_KEY_1)?;
+    let service_type = ServiceType::from_str("gvpn:exit")?;
+    let metadata = ServiceMetadata::try_from(b"metadata".to_vec())?;
+    let (b_gen, s_gen) = basic_gens(&key);
+
+    assert!(
+        b_gen
+            .register_service(service_type, metadata.clone(), HoprBalance::from(1))
+            .is_err()
+    );
+    assert!(
+        s_gen
+            .register_service(service_type, metadata, HoprBalance::from(1))
+            .is_err()
+    );
+    Ok(())
+}

--- a/src/chain/payload/mod.rs
+++ b/src/chain/payload/mod.rs
@@ -159,6 +159,7 @@ pub(crate) mod tests {
         "node_safe_registry": "0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0",
         "node_safe_migration": "0x222222222222890352Ed9Ca694EdeAC49528D8F3",
         "node_stake_factory": "0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2",
+        "service_registry": "0x9A676e781A523b5d0C0e43731313A708CB607508",
         "token": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
         "ticket_price_oracle": "0x442df1d946303fB088C9377eefdaeA84146DA0A6",
         "winning_probability_oracle": "0xC15675d4CCa538D91a91a8D3EcFBB8499C3B0471",

--- a/src/chain/payload/mod.rs
+++ b/src/chain/payload/mod.rs
@@ -129,6 +129,29 @@ pub trait PayloadGenerator {
     /// the node no longer manages the funds.
     fn deregister_node_by_safe(&self) -> Result<Self::TxRequest>;
 
+    /// Creates an atomic service-registry registration payload for this node.
+    ///
+    /// Safe-backed generators bundle an exact wxHOPR approval with the registry call. The
+    /// approval is consumed by the registry in the same transaction and therefore also protects
+    /// the caller against a concurrent burn increase.
+    fn register_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        registration_burn: HoprBalance,
+    ) -> Result<Self::TxRequest>;
+
+    /// Creates an atomic service-registry update payload for this node.
+    fn update_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        update_burn: HoprBalance,
+    ) -> Result<Self::TxRequest>;
+
+    /// Creates a service-registry deregistration payload for this node.
+    fn deregister_service(&self, service_type: ServiceType) -> Result<Self::TxRequest>;
+
     /// Creates a transaction payload to deploy a new Safe instance with the initial
     /// `balance` transferred from the signer and `admins` as Safe owners.
     ///

--- a/src/chain/payload/static_based.rs
+++ b/src/chain/payload/static_based.rs
@@ -47,6 +47,14 @@ mod selectors {
     pub const REGISTER_SAFE_BY_NODE: [u8; 4] = hex!("7f935931");
     /// `deregisterNodeBySafe(address)`
     pub const DEREGISTER_NODE_BY_SAFE: [u8; 4] = hex!("91607c4c");
+    /// `selfRegister(bytes32,address,bytes)`
+    pub const SELF_REGISTER: [u8; 4] = hex!("326005af");
+    /// `selfUpdate(bytes32,address,bytes)`
+    pub const SELF_UPDATE: [u8; 4] = hex!("210c3298");
+    /// `selfDeregister(bytes32,address)`
+    pub const SELF_DEREGISTER: [u8; 4] = hex!("1e46f907");
+    /// Safe MultiSend `multiSend(bytes)`
+    pub const MULTI_SEND: [u8; 4] = hex!("8d80ff0a");
     /// Gnosis Safe `execTransactionFromModule(address,uint256,bytes,uint8)`
     pub const EXEC_TRANSACTION_FROM_MODULE: [u8; 4] = hex!("468721a7");
     /// `fundChannel(address,uint96)`
@@ -154,7 +162,11 @@ fn encode_deregister_node_by_safe(node_addr: [u8; 20]) -> Vec<u8> {
 }
 
 /// Gnosis Safe module: `execTransactionFromModule(address,uint256,bytes,uint8)`.
-fn encode_exec_from_module(to: [u8; 20], call_data: &[u8]) -> Vec<u8> {
+fn encode_exec_from_module_with_operation(
+    to: [u8; 20],
+    call_data: &[u8],
+    operation: u8,
+) -> Vec<u8> {
     // Layout: selector | to | value(0) | offset | operation(0) | tail
     let offset = 4usize * 32; // 4 head slots → offset = 128
     let tail = abi_dyn_tail(call_data);
@@ -163,9 +175,61 @@ fn encode_exec_from_module(to: [u8; 20], call_data: &[u8]) -> Vec<u8> {
     out.extend_from_slice(&addr32(to));
     out.extend_from_slice(&[0u8; 32]); // value = 0
     out.extend_from_slice(&word_usize(offset));
-    out.extend_from_slice(&[0u8; 32]); // operation = 0 (Call)
+    out.extend_from_slice(&right_align32(&[operation]));
     out.extend_from_slice(&tail);
     out
+}
+
+fn encode_exec_from_module(to: [u8; 20], call_data: &[u8]) -> Vec<u8> {
+    encode_exec_from_module_with_operation(to, call_data, 0)
+}
+
+fn encode_service_write(
+    selector: [u8; 4],
+    service_type: ServiceType,
+    node: [u8; 20],
+    metadata: &[u8],
+) -> Vec<u8> {
+    call_with_bytes(
+        selector,
+        &[service_type.as_encoded(), addr32(node)],
+        metadata,
+    )
+}
+
+fn encode_service_deregister(service_type: ServiceType, node: [u8; 20]) -> Vec<u8> {
+    static_call(
+        selectors::SELF_DEREGISTER,
+        &[service_type.as_encoded(), addr32(node)],
+    )
+}
+
+fn encode_multi_send_transaction(to: [u8; 20], data: &[u8]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(85 + data.len());
+    encoded.push(0);
+    encoded.extend_from_slice(&to);
+    encoded.extend_from_slice(&[0u8; 32]);
+    encoded.extend_from_slice(&word_usize(data.len()));
+    encoded.extend_from_slice(data);
+    encoded
+}
+
+const SAFE_MULTI_SEND_ADDRESS: [u8; 20] = hex!("38869bf66a61cf6bdb996a6ae40d5853fd43b526");
+
+fn paid_service_registry_payload(
+    token: [u8; 20],
+    registry: [u8; 20],
+    registry_call: &[u8],
+    burn: HoprBalance,
+) -> Vec<u8> {
+    let mut transactions = Vec::new();
+    if !burn.is_zero() {
+        let approval = encode_approve(registry, &burn.amount().to_be_bytes());
+        transactions.extend_from_slice(&encode_multi_send_transaction(token, &approval));
+    }
+    transactions.extend_from_slice(&encode_multi_send_transaction(registry, registry_call));
+    let multi_send = call_with_bytes(selectors::MULTI_SEND, &[], &transactions);
+    encode_exec_from_module_with_operation(SAFE_MULTI_SEND_ADDRESS, &multi_send, 1)
 }
 
 fn encode_fund_channel(account: [u8; 20], amount_word: [u8; 32]) -> Vec<u8> {
@@ -672,6 +736,54 @@ impl PayloadGenerator for BasicPayloadGenerator {
         ))
     }
 
+    fn register_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        registration_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        if !registration_burn.is_zero() {
+            return Err(InvalidState(
+                "paid service writes require a Safe payload generator",
+            ));
+        }
+        Ok(TransactionRequest::default()
+            .with_input(encode_service_write(
+                selectors::SELF_REGISTER,
+                service_type,
+                self.me.into(),
+                metadata.as_ref(),
+            ))
+            .with_to(self.contract_addrs.service_registry.into()))
+    }
+
+    fn update_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        update_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        if !update_burn.is_zero() {
+            return Err(InvalidState(
+                "paid service writes require a Safe payload generator",
+            ));
+        }
+        Ok(TransactionRequest::default()
+            .with_input(encode_service_write(
+                selectors::SELF_UPDATE,
+                service_type,
+                self.me.into(),
+                metadata.as_ref(),
+            ))
+            .with_to(self.contract_addrs.service_registry.into()))
+    }
+
+    fn deregister_service(&self, service_type: ServiceType) -> payload::Result<Self::TxRequest> {
+        Ok(TransactionRequest::default()
+            .with_input(encode_service_deregister(service_type, self.me.into()))
+            .with_to(self.contract_addrs.service_registry.into()))
+    }
+
     fn deploy_safe(
         &self,
         balance: HoprBalance,
@@ -841,6 +953,57 @@ impl PayloadGenerator for SafePayloadGenerator {
             .with_input(encode_deregister_node_by_safe(self.me.into()))
             .with_to(self.module.into())
             .with_gas_limit(DEFAULT_TX_GAS))
+    }
+
+    fn register_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        registration_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        let call = encode_service_write(
+            selectors::SELF_REGISTER,
+            service_type,
+            self.me.into(),
+            metadata.as_ref(),
+        );
+        Ok(TransactionRequest::default()
+            .with_input(paid_service_registry_payload(
+                self.contract_addrs.token.into(),
+                self.contract_addrs.service_registry.into(),
+                &call,
+                registration_burn,
+            ))
+            .with_to(self.module.into())
+            .with_gas_limit(DEFAULT_TX_GAS))
+    }
+
+    fn update_service(
+        &self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+        update_burn: HoprBalance,
+    ) -> payload::Result<Self::TxRequest> {
+        let call = encode_service_write(
+            selectors::SELF_UPDATE,
+            service_type,
+            self.me.into(),
+            metadata.as_ref(),
+        );
+        Ok(TransactionRequest::default()
+            .with_input(paid_service_registry_payload(
+                self.contract_addrs.token.into(),
+                self.contract_addrs.service_registry.into(),
+                &call,
+                update_burn,
+            ))
+            .with_to(self.module.into())
+            .with_gas_limit(DEFAULT_TX_GAS))
+    }
+
+    fn deregister_service(&self, service_type: ServiceType) -> payload::Result<Self::TxRequest> {
+        let call = encode_service_deregister(service_type, self.me.into());
+        Ok(self.module_exec_tx(self.contract_addrs.service_registry.into(), &call))
     }
 
     fn deploy_safe(

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -26,6 +26,8 @@ pub mod path;
 pub mod protocol;
 /// Implements types for packet routing.
 pub mod routing;
+/// Implements types for the on-chain registry of services offered by HOPR nodes.
+pub mod service;
 /// Implements types for tickets.
 pub mod tickets;
 
@@ -94,7 +96,7 @@ pub use multiaddr::Multiaddr;
 pub mod prelude {
     pub use super::{
         Multiaddr, NodeId, account::*, announcement::*, channels::*, errors::CoreTypesError,
-        path::*, protocol::*, routing::*, tickets::*,
+        path::*, protocol::*, routing::*, service::*, tickets::*,
     };
 }
 

--- a/src/internal/service.rs
+++ b/src/internal/service.rs
@@ -274,14 +274,22 @@ mod bindings_conversions {
 
     use super::*;
 
-    impl From<B256> for ServiceType {
-        /// Takes the id as-is, without rejecting the zero id.
+    impl TryFrom<B256> for ServiceType {
+        type Error = GeneralError;
+
+        /// Rejects the zero id, exactly as the contract does.
         ///
-        /// Values decoded from chain data can hold any `bytes32`, and a consumer that is
-        /// mirroring logs wants them all. Use `ServiceType::try_from(value.0)` where the zero id
-        /// has to be rejected instead.
-        fn from(value: B256) -> Self {
-            Self(value.0)
+        /// No registry log can carry a zero id: `registerServiceType` is the only path that
+        /// creates a service type and it reverts with `ZeroServiceType`, and every other event
+        /// is keyed on a type that already exists. A zero id reaching this conversion therefore
+        /// means the caller decoded something that is not a registry log.
+        ///
+        /// This deliberately has no infallible counterpart. An `impl From<B256>` would make the
+        /// standard library's blanket `TryFrom` apply instead, and every `try_from` call site
+        /// would silently stop checking anything while still compiling and still returning
+        /// `Result`.
+        fn try_from(value: B256) -> Result<Self, Self::Error> {
+            Self::try_from(value.0)
         }
     }
 
@@ -297,7 +305,7 @@ mod bindings_conversions {
             let registered_at = seconds_to_system_time(value.registeredAt.to::<u64>());
 
             Self::new(
-                value.serviceType.into(),
+                value.serviceType.try_into()?,
                 Address::from(value.node.0.0),
                 Address::from(value.safe.0.0),
                 value.metadata.to_vec().try_into()?,
@@ -318,7 +326,7 @@ mod bindings_conversions {
             let updated_at = seconds_to_system_time(value.updatedAt.to::<u64>());
 
             Self::new(
-                value.serviceType.into(),
+                value.serviceType.try_into()?,
                 Address::from(value.node.0.0),
                 Address::from(value.safe.0.0),
                 value.metadata.to_vec().try_into()?,
@@ -596,14 +604,18 @@ mod tests {
         }
 
         #[test]
-        fn service_type_converts_from_a_b256_unchecked() {
+        fn service_type_conversion_from_b256_rejects_the_zero_id() -> anyhow::Result<()> {
             assert_eq!(
                 ServiceType::GVPN_EXIT,
-                ServiceType::from(B256::from(GVPN_EXIT_ENCODED))
+                ServiceType::try_from(B256::from(GVPN_EXIT_ENCODED))?
             );
 
-            // Chain data may hold any id, so the unchecked conversion accepts the zero id too.
-            assert_eq!([0u8; 32], ServiceType::from(B256::ZERO).as_encoded());
+            // No registry log can carry the zero id, so the conversion has no reason to admit
+            // it: `registerServiceType` is the only path that creates a type and it reverts
+            // with `ZeroServiceType`.
+            assert!(ServiceType::try_from(B256::ZERO).is_err());
+
+            Ok(())
         }
 
         #[test]

--- a/src/internal/service.rs
+++ b/src/internal/service.rs
@@ -1,0 +1,658 @@
+//! Types mirroring `HoprServiceRegistry`, the permissionless on-chain registry of the services
+//! that HOPR nodes offer.
+//!
+//! The registry treats service type ids and entry metadata as opaque data: each service type
+//! documents its own metadata schema and its own Session-level protocol. These types therefore
+//! validate only what the contract itself guarantees - a non-zero type id and the metadata length
+//! cap - and leave the meaning of the bytes to the consumer.
+//!
+//! This is read-side vocabulary only. Building registry calldata is the job of the operator
+//! tooling, which encodes it from the contract bindings directly.
+
+use std::fmt::{Debug, Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::primitive::{
+    bounded::BoundedVec,
+    errors::GeneralError,
+    prelude::{Address, BytesRepresentable, ToHex},
+};
+
+/// Right-pads `bytes` with zeroes into a [`ServiceType::SIZE`]-wide array.
+///
+/// Callers must ensure `bytes` is at most [`ServiceType::SIZE`] long; a longer input fails to
+/// compile in a `const` context and panics otherwise.
+const fn right_pad(bytes: &[u8]) -> [u8; ServiceType::SIZE] {
+    let mut out = [0u8; ServiceType::SIZE];
+    let mut i = 0;
+    while i < bytes.len() {
+        out[i] = bytes[i];
+        i += 1;
+    }
+    out
+}
+
+/// Identifier of a service type in `HoprServiceRegistry`, a `bytes32` on-chain.
+///
+/// By convention the id holds right-padded ASCII, so that it stays human-readable in explorers
+/// and in event topics: `bytes32("gvpn:exit")` is
+/// `0x6776706e3a657869740000000000000000000000000000000000000000000000`. The contract does
+/// **not** enforce that convention, so any non-zero 32-byte value can appear on-chain. Use
+/// [`ServiceType::as_ascii`] to find out whether a given id follows it.
+///
+/// The only invariant the contract does enforce is that the id is not zero (`ZeroServiceType`),
+/// which [`TryFrom`] upholds here.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(try_from = "[u8; ServiceType::SIZE]", into = "[u8; ServiceType::SIZE]")
+)]
+pub struct ServiceType([u8; Self::SIZE]);
+
+impl ServiceType {
+    /// Canonical id of the GnosisVPN exit-node service, `bytes32("gvpn:exit")`.
+    ///
+    /// A type id is only trustworthy when it comes from the documentation of the service, never
+    /// from the way it reads: type ids are first-come-first-served and the registry places no
+    /// meaning on a name. A consumer that resolves `gvpn:exit` by parsing the string rather than
+    /// by using this constant can be pointed at a squatted type.
+    pub const GVPN_EXIT: Self = Self(right_pad(b"gvpn:exit"));
+
+    /// The raw 32-byte id, ready to be handed to an ABI encoder as a `bytes32`.
+    pub fn as_encoded(&self) -> [u8; Self::SIZE] {
+        self.0
+    }
+
+    /// Decodes the id back into its ASCII name, if it follows the right-padded ASCII convention.
+    ///
+    /// Returns `None` for any id that does not: one holding non-ASCII bytes, an interior NUL
+    /// byte, or a character outside the printable, non-space range accepted by [`FromStr`].
+    pub fn as_ascii(&self) -> Option<&str> {
+        let len = self.0.iter().rposition(|b| *b != 0)? + 1;
+        let name = std::str::from_utf8(&self.0[..len]).ok()?;
+
+        name.bytes().all(|b| b.is_ascii_graphic()).then_some(name)
+    }
+}
+
+impl AsRef<[u8]> for ServiceType {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<&[u8]> for ServiceType {
+    type Error = GeneralError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let value: [u8; Self::SIZE] = value
+            .try_into()
+            .map_err(|_| GeneralError::ParseError("ServiceType".into()))?;
+
+        Self::try_from(value)
+    }
+}
+
+impl TryFrom<[u8; ServiceType::SIZE]> for ServiceType {
+    type Error = GeneralError;
+
+    fn try_from(value: [u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        if value == [0u8; Self::SIZE] {
+            // The contract rejects this id with `ZeroServiceType`.
+            Err(GeneralError::ParseError("zero service type".into()))
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl From<ServiceType> for [u8; ServiceType::SIZE] {
+    fn from(value: ServiceType) -> Self {
+        value.0
+    }
+}
+
+impl BytesRepresentable for ServiceType {
+    /// Size of the service type id when encoded as bytes, matching the `bytes32` on-chain.
+    const SIZE: usize = 32;
+}
+
+impl std::str::FromStr for ServiceType {
+    type Err = GeneralError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() || s.len() > Self::SIZE {
+            return Err(GeneralError::ParseError(
+                "service type name must be 1 to 32 bytes long".into(),
+            ));
+        }
+
+        if !s.bytes().all(|b| b.is_ascii_graphic()) {
+            // Space is excluded along with the control characters: it is indistinguishable from
+            // the padding to the eye, which makes it a poor character for an identifier.
+            return Err(GeneralError::ParseError(
+                "service type name must be printable non-space ASCII".into(),
+            ));
+        }
+
+        Ok(Self(right_pad(s.as_bytes())))
+    }
+}
+
+impl Display for ServiceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.as_ascii() {
+            Some(name) => f.write_str(name),
+            // The convention is not enforced on-chain, so fall back to the raw id.
+            None => f.write_str(&self.to_hex()),
+        }
+    }
+}
+
+impl Debug for ServiceType {
+    // Intentionally the same as Display
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+/// Opaque metadata of a single registry entry.
+///
+/// The registry places no meaning on these bytes; the schema belongs to the service type. The
+/// only rule is the length cap, see [`ServiceMetadata::MAX_LENGTH`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "Vec<u8>", into = "Vec<u8>"))]
+pub struct ServiceMetadata(BoundedVec<u8, { ServiceMetadata::MAX_LENGTH }>);
+
+impl ServiceMetadata {
+    /// Hard cap on the length of the metadata of an entry.
+    ///
+    /// Mirrors `MAX_METADATA_LENGTH` in `ServiceRegistry.sol`. The contract is not upgradeable
+    /// and applies the cap on every write path, so this value is permanent and can never be
+    /// raised. A service type may make it smaller through its requirement contract.
+    pub const MAX_LENGTH: usize = 2048;
+}
+
+impl TryFrom<Vec<u8>> for ServiceMetadata {
+    type Error = GeneralError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        // `BoundedVec::try_from` rejects anything above the cap; its `FromIterator`, which
+        // truncates silently instead, is deliberately not reachable through this type.
+        value.try_into().map(Self)
+    }
+}
+
+impl From<ServiceMetadata> for Vec<u8> {
+    fn from(value: ServiceMetadata) -> Self {
+        value.0.into()
+    }
+}
+
+impl AsRef<[u8]> for ServiceMetadata {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+/// A single entry in `HoprServiceRegistry`: one node offering one service type.
+///
+/// This mirrors the contract's `Entry` struct together with the two fields that key it, the
+/// service type and the node.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ServiceEntry {
+    /// Service type this entry is registered under.
+    pub service_type: ServiceType,
+    /// Node offering the service.
+    pub node: Address,
+    /// Safe bound to the node that performed the last write to this entry.
+    pub safe: Address,
+    /// Opaque metadata, with a schema that belongs to the service type.
+    pub metadata: ServiceMetadata,
+    /// When the entry was registered.
+    pub registered_at: SystemTime,
+    /// When the entry was last updated; equal to [`Self::registered_at`] until the first update.
+    pub updated_at: SystemTime,
+}
+
+impl ServiceEntry {
+    /// Creates a new entry, checking the invariants the contract guarantees on its timestamps.
+    ///
+    /// Fails unless `registered_at` is after the Unix epoch - the contract uses a zero
+    /// `registeredAt` as its "entry absent" sentinel - and `updated_at` is at or after
+    /// `registered_at`. Registration itself sets `updatedAt` to `registeredAt`, so the two being
+    /// equal is the state of every entry that has never been updated.
+    pub fn new(
+        service_type: ServiceType,
+        node: Address,
+        safe: Address,
+        metadata: ServiceMetadata,
+        registered_at: SystemTime,
+        updated_at: SystemTime,
+    ) -> Result<Self, GeneralError> {
+        if registered_at <= UNIX_EPOCH {
+            return Err(GeneralError::InvalidInput);
+        }
+
+        if updated_at < registered_at {
+            return Err(GeneralError::InvalidInput);
+        }
+
+        Ok(Self {
+            service_type,
+            node,
+            safe,
+            metadata,
+            registered_at,
+            updated_at,
+        })
+    }
+}
+
+impl Display for ServiceEntry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "service {} of node {} (safe: {}, {} bytes of metadata)",
+            self.service_type,
+            self.node,
+            self.safe,
+            self.metadata.as_ref().len()
+        )
+    }
+}
+
+#[cfg(feature = "use-bindings")]
+mod bindings_conversions {
+    use std::time::Duration;
+
+    use hopr_bindings::exports::alloy::primitives::B256;
+    use hopr_bindings::hopr_service_registry::HoprServiceRegistry::{Registered, Updated};
+
+    use super::*;
+
+    impl From<B256> for ServiceType {
+        /// Takes the id as-is, without rejecting the zero id.
+        ///
+        /// Values decoded from chain data can hold any `bytes32`, and a consumer that is
+        /// mirroring logs wants them all. Use `ServiceType::try_from(value.0)` where the zero id
+        /// has to be rejected instead.
+        fn from(value: B256) -> Self {
+            Self(value.0)
+        }
+    }
+
+    /// Converts a `uint48` block timestamp in seconds into a [`SystemTime`].
+    fn seconds_to_system_time(seconds: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(seconds)
+    }
+
+    impl TryFrom<&Registered> for ServiceEntry {
+        type Error = GeneralError;
+
+        fn try_from(value: &Registered) -> Result<Self, Self::Error> {
+            let registered_at = seconds_to_system_time(value.registeredAt.to::<u64>());
+
+            Self::new(
+                value.serviceType.into(),
+                Address::from(value.node.0.0),
+                Address::from(value.safe.0.0),
+                value.metadata.to_vec().try_into()?,
+                registered_at,
+                // Registration sets `updatedAt` to `registeredAt`.
+                registered_at,
+            )
+        }
+    }
+
+    impl TryFrom<&Updated> for ServiceEntry {
+        type Error = GeneralError;
+
+        /// The `Updated` event omits `registeredAt`, because an update leaves it untouched. The
+        /// resulting entry therefore carries `updated_at` in both timestamp fields. A consumer
+        /// holding the previous state of the entry should keep its own `registered_at`.
+        fn try_from(value: &Updated) -> Result<Self, Self::Error> {
+            let updated_at = seconds_to_system_time(value.updatedAt.to::<u64>());
+
+            Self::new(
+                value.serviceType.into(),
+                Address::from(value.node.0.0),
+                Address::from(value.safe.0.0),
+                value.metadata.to_vec().try_into()?,
+                updated_at,
+                updated_at,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use hex_literal::hex;
+
+    use super::*;
+    use crate::primitive::prelude::*;
+
+    /// `bytes32("gvpn:exit")` as given in `design-service-discovery.md`, section 3.1.
+    const GVPN_EXIT_ENCODED: [u8; 32] =
+        hex!("6776706e3a657869740000000000000000000000000000000000000000000000");
+
+    const NODE: [u8; 20] = hex!("2cDD13ddB0346E0F620C8E5826Da5d7230341c6E");
+    const SAFE: [u8; 20] = hex!("42e0e02c7b7c46ec3d5b8c3fdb2f2e3f2a4b5c6d");
+
+    fn node() -> Address {
+        Address::from(NODE)
+    }
+
+    fn safe() -> Address {
+        Address::from(SAFE)
+    }
+
+    #[test]
+    fn service_type_from_str_uses_the_canonical_right_padded_encoding() -> anyhow::Result<()> {
+        let parsed: ServiceType = "gvpn:exit".parse()?;
+
+        assert_eq!(GVPN_EXIT_ENCODED, parsed.as_encoded());
+        assert_eq!(ServiceType::GVPN_EXIT, parsed);
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_round_trips_between_from_str_and_display() -> anyhow::Result<()> {
+        for name in ["gvpn:exit", "a", &"z".repeat(32)] {
+            let parsed: ServiceType = name.parse()?;
+            assert_eq!(name, parsed.to_string());
+            assert_eq!(Some(name), parsed.as_ascii());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_from_str_rejects_invalid_names() {
+        assert!("".parse::<ServiceType>().is_err());
+        assert!("z".repeat(33).parse::<ServiceType>().is_err());
+        assert!("gvpn:exít".parse::<ServiceType>().is_err());
+        assert!("gvpn exit".parse::<ServiceType>().is_err());
+        assert!("gvpn\texit".parse::<ServiceType>().is_err());
+    }
+
+    #[test]
+    fn service_type_try_from_bytes_rejects_zero_and_wrong_lengths() -> anyhow::Result<()> {
+        assert_eq!(
+            ServiceType::GVPN_EXIT,
+            ServiceType::try_from(GVPN_EXIT_ENCODED.as_ref())?
+        );
+
+        assert!(ServiceType::try_from([0u8; 32].as_ref()).is_err());
+        assert!(ServiceType::try_from([0u8; 32]).is_err());
+        assert!(ServiceType::try_from([1u8; 31].as_ref()).is_err());
+        assert!(ServiceType::try_from([1u8; 33].as_ref()).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_round_trips_through_hex() -> anyhow::Result<()> {
+        let hex = ServiceType::GVPN_EXIT.to_hex();
+
+        assert_eq!(
+            "0x6776706e3a657869740000000000000000000000000000000000000000000000",
+            hex
+        );
+        assert_eq!(ServiceType::GVPN_EXIT, ServiceType::from_hex(&hex)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_display_falls_back_to_hex_for_non_ascii_ids() -> anyhow::Result<()> {
+        // The contract does not enforce the ASCII convention, so any non-zero id can appear.
+        let raw = ServiceType::try_from([0xffu8; 32].as_ref())?;
+
+        assert_eq!(None, raw.as_ascii());
+        assert_eq!(raw.to_hex(), raw.to_string());
+
+        // An id with an interior NUL byte is not ASCII-decodable either.
+        let mut interior_nul = GVPN_EXIT_ENCODED;
+        interior_nul[4] = 0;
+        let raw = ServiceType::try_from(interior_nul.as_ref())?;
+
+        assert_eq!(None, raw.as_ascii());
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_type_is_usable_as_a_map_key() -> anyhow::Result<()> {
+        let other: ServiceType = "gvpn:entry".parse()?;
+
+        let hash_map = HashMap::from([(ServiceType::GVPN_EXIT, 1), (other, 2)]);
+        assert_eq!(Some(&1), hash_map.get(&ServiceType::GVPN_EXIT));
+
+        let btree_map = BTreeMap::from([(ServiceType::GVPN_EXIT, 1), (other, 2)]);
+        assert_eq!(Some(&2), btree_map.get(&other));
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_metadata_enforces_the_contract_cap() -> anyhow::Result<()> {
+        assert_eq!(2048, ServiceMetadata::MAX_LENGTH);
+
+        for len in [0, 1, ServiceMetadata::MAX_LENGTH] {
+            let bytes = vec![0xab; len];
+            let metadata = ServiceMetadata::try_from(bytes.clone())?;
+
+            assert_eq!(bytes.as_slice(), metadata.as_ref());
+            assert_eq!(bytes, Vec::from(metadata));
+        }
+
+        assert!(ServiceMetadata::try_from(vec![0xab; ServiceMetadata::MAX_LENGTH + 1]).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_entry_new_enforces_the_timestamp_invariants() -> anyhow::Result<()> {
+        let registered_at = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let updated_at = registered_at + Duration::from_secs(60);
+        let metadata = ServiceMetadata::try_from(b"exit-node".to_vec())?;
+
+        // Registration sets `updated_at` to `registered_at`.
+        let entry = ServiceEntry::new(
+            ServiceType::GVPN_EXIT,
+            node(),
+            safe(),
+            metadata.clone(),
+            registered_at,
+            registered_at,
+        )?;
+        assert_eq!(registered_at, entry.updated_at);
+
+        assert!(
+            ServiceEntry::new(
+                ServiceType::GVPN_EXIT,
+                node(),
+                safe(),
+                metadata.clone(),
+                registered_at,
+                updated_at,
+            )
+            .is_ok()
+        );
+
+        // An update cannot precede the registration.
+        assert!(
+            ServiceEntry::new(
+                ServiceType::GVPN_EXIT,
+                node(),
+                safe(),
+                metadata.clone(),
+                updated_at,
+                registered_at,
+            )
+            .is_err()
+        );
+
+        // A zero `registered_at` is the contract's "entry absent" sentinel.
+        assert!(
+            ServiceEntry::new(
+                ServiceType::GVPN_EXIT,
+                node(),
+                safe(),
+                metadata,
+                UNIX_EPOCH,
+                UNIX_EPOCH,
+            )
+            .is_err()
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn service_types_round_trip_through_serde() -> anyhow::Result<()> {
+        let service_type = ServiceType::GVPN_EXIT;
+        assert_eq!(
+            service_type,
+            postcard::from_bytes(&postcard::to_allocvec(&service_type)?)?
+        );
+
+        let metadata = ServiceMetadata::try_from(b"exit-node".to_vec())?;
+        assert_eq!(
+            metadata,
+            postcard::from_bytes::<ServiceMetadata>(&postcard::to_allocvec(&metadata)?)?
+        );
+
+        let entry = ServiceEntry::new(
+            service_type,
+            node(),
+            safe(),
+            metadata,
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            UNIX_EPOCH + Duration::from_secs(1_700_000_060),
+        )?;
+        assert_eq!(
+            entry,
+            postcard::from_bytes::<ServiceEntry>(&postcard::to_allocvec(&entry)?)?
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_upholds_the_service_type_and_metadata_invariants() -> anyhow::Result<()> {
+        let zero_id = postcard::to_allocvec(&[0u8; 32])?;
+        assert!(postcard::from_bytes::<ServiceType>(&zero_id).is_err());
+
+        let too_long = postcard::to_allocvec(&vec![0xab; ServiceMetadata::MAX_LENGTH + 1])?;
+        assert!(postcard::from_bytes::<ServiceMetadata>(&too_long).is_err());
+
+        Ok(())
+    }
+
+    #[cfg(feature = "use-bindings")]
+    mod bindings {
+        use hopr_bindings::exports::alloy::primitives::{
+            Address as AlloyAddress, B256, Bytes, U256, aliases::U48,
+        };
+        use hopr_bindings::hopr_service_registry::HoprServiceRegistry::{Registered, Updated};
+
+        use super::*;
+
+        const REGISTERED_AT: u64 = 1_700_000_000;
+        const UPDATED_AT: u64 = 1_700_000_060;
+
+        fn registered(metadata: Vec<u8>) -> Registered {
+            Registered {
+                serviceType: B256::from(GVPN_EXIT_ENCODED),
+                node: AlloyAddress::from(NODE),
+                safe: AlloyAddress::from(SAFE),
+                metadata: Bytes::from(metadata),
+                registeredAt: U48::from(REGISTERED_AT),
+                burned: U256::from(1u64),
+            }
+        }
+
+        fn updated(metadata: Vec<u8>) -> Updated {
+            Updated {
+                serviceType: B256::from(GVPN_EXIT_ENCODED),
+                node: AlloyAddress::from(NODE),
+                safe: AlloyAddress::from(SAFE),
+                metadata: Bytes::from(metadata),
+                updatedAt: U48::from(UPDATED_AT),
+                burned: U256::from(1u64),
+            }
+        }
+
+        #[test]
+        fn service_type_converts_from_a_b256_unchecked() {
+            assert_eq!(
+                ServiceType::GVPN_EXIT,
+                ServiceType::from(B256::from(GVPN_EXIT_ENCODED))
+            );
+
+            // Chain data may hold any id, so the unchecked conversion accepts the zero id too.
+            assert_eq!([0u8; 32], ServiceType::from(B256::ZERO).as_encoded());
+        }
+
+        #[test]
+        fn registered_event_converts_to_a_service_entry() -> anyhow::Result<()> {
+            let entry = ServiceEntry::try_from(&registered(b"exit-node".to_vec()))?;
+
+            assert_eq!(ServiceType::GVPN_EXIT, entry.service_type);
+            assert_eq!(node(), entry.node);
+            assert_eq!(safe(), entry.safe);
+            assert_eq!(b"exit-node".as_ref(), entry.metadata.as_ref());
+            assert_eq!(
+                UNIX_EPOCH + Duration::from_secs(REGISTERED_AT),
+                entry.registered_at
+            );
+            assert_eq!(
+                UNIX_EPOCH + Duration::from_secs(REGISTERED_AT),
+                entry.updated_at
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn updated_event_converts_to_a_service_entry() -> anyhow::Result<()> {
+            let entry = ServiceEntry::try_from(&updated(b"exit-node".to_vec()))?;
+
+            assert_eq!(ServiceType::GVPN_EXIT, entry.service_type);
+            assert_eq!(node(), entry.node);
+            assert_eq!(safe(), entry.safe);
+            assert_eq!(b"exit-node".as_ref(), entry.metadata.as_ref());
+            assert_eq!(
+                UNIX_EPOCH + Duration::from_secs(UPDATED_AT),
+                entry.updated_at
+            );
+            // The event does not carry `registeredAt`, so the conversion mirrors `updated_at`.
+            assert_eq!(
+                UNIX_EPOCH + Duration::from_secs(UPDATED_AT),
+                entry.registered_at
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn oversized_metadata_fails_the_conversion_instead_of_truncating() {
+            let too_long = vec![0xab; ServiceMetadata::MAX_LENGTH + 1];
+
+            assert!(ServiceEntry::try_from(&registered(too_long.clone())).is_err());
+            assert!(ServiceEntry::try_from(&updated(too_long)).is_err());
+        }
+    }
+}

--- a/src/internal/service.rs
+++ b/src/internal/service.rs
@@ -6,8 +6,8 @@
 //! validate only what the contract itself guarantees - a non-zero type id and the metadata length
 //! cap - and leave the meaning of the bytes to the consumer.
 //!
-//! This is read-side vocabulary only. Building registry calldata is the job of the operator
-//! tooling, which encodes it from the contract bindings directly.
+//! The same validated identifiers and metadata are also accepted by the chain payload generators,
+//! so reads and writes cannot disagree about the registry's input invariants.
 
 use std::fmt::{Debug, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
- Adds the service registry types, the chain events of the registry and the `service_registry`
  contract address. Bumps the crate to 2.3.0.
- The new contract address field has no default value. A client that carries this version needs
  a bloklid that reports the address.
- Fixes two smaller issues: a zero service type is now rejected, and the node safe migration
  address is now part of the contract address iterator.

## Depends on

- hoprnet/contracts#137 - this branch pins `hopr-bindings` to its git rev.

## Follow-up

- [ ] After hoprnet/contracts#137 merges and `hopr-bindings` 4.12.2 is published, replace the
      `git`/`rev` pin in `Cargo.toml` with `version = "4.12.2"`, then publish `hopr-types`
      2.3.0 for the repositories downstream.
