### PR TITLE
feat: add Bn254PublicKey and Bn254Keypair types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,9 +789,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -802,13 +813,34 @@ checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
- "ark-poly",
+ "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -997,6 +1029,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,7 +1226,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e657c11493f07dd18f0c6055b58e77ca71e30ed34f2804468b22f89e36dc0a"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "elliptic-curve 0.14.1",
@@ -2629,6 +2676,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash",
  "serde",
  "serde_core",
@@ -2732,11 +2780,15 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayvec",
  "async-trait",
  "babyjubjub-ec",
@@ -4960,8 +5012,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
 dependencies = [
- "ark-bn254",
- "ark-ec",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-types"
-version = "2.2.2"
+version = "2.3.0"
 description = "Complete collection of Rust types used in Hoprnet and other related projects"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -44,6 +44,10 @@ random = ["dep:hybrid-array", "dep:rand"]
 crypto = [
   "primitive",
   "random",
+  "dep:ark-bn254",
+  "dep:ark-ec",
+  "dep:ark-ff",
+  "dep:ark-serialize",
   "dep:arrayvec",
   "dep:aes",
   "dep:blake3",
@@ -121,6 +125,10 @@ telemetry = [
 aes = { version = "0.9.2", optional = true }
 anyhow = { version = "1.0.104", optional = true }
 aquamarine = { version = "0.6.0", optional = true }
+ark-bn254 = { version = "0.6", optional = true }
+ark-ec = { version = "0.6", optional = true }
+ark-ff = { version = "0.6", optional = true }
+ark-serialize = { version = "0.6", optional = true }
 arrayvec = { version = "0.7.8", optional = true }
 async-trait = { version = "0.1.91", optional = true }
 babyjubjub-ec = { version = "0.4.0", optional = true, features = [

--- a/src/crypto/keypairs.rs
+++ b/src/crypto/keypairs.rs
@@ -10,6 +10,7 @@ use sha2::Sha512;
 use subtle::{Choice, ConstantTimeEq};
 
 use crate::crypto::types::BjjPublicKey;
+use crate::crypto::types::Bn254PublicKey;
 use crate::crypto::{
     errors,
     errors::CryptoError::InvalidInputValue,
@@ -211,6 +212,47 @@ impl From<&BjjKeypair> for BjjPublicKey {
     }
 }
 
+/// Represents a keypair consisting of BN254 private and public keys.
+#[derive(Clone, Debug)]
+pub struct Bn254Keypair(SecretValue<typenum::U32>, Bn254PublicKey);
+
+impl Keypair for Bn254Keypair {
+    type Public = Bn254PublicKey;
+    type SecretLen = typenum::U32;
+
+    fn random() -> Self {
+        let mut ret = Self::from_secret(SecretValue::<typenum::U32>::random().as_ref());
+        while ret.is_err() {
+            ret = Self::from_secret(SecretValue::<typenum::U32>::random().as_ref());
+        }
+        ret.unwrap()
+    }
+
+    fn from_secret(bytes: &[u8]) -> errors::Result<Self> {
+        Bn254PublicKey::from_privkey(bytes).and_then(|pub_key| Ok(Self(bytes.try_into()?, pub_key)))
+    }
+
+    fn secret(&self) -> &SecretValue<Self::SecretLen> {
+        &self.0
+    }
+
+    fn public(&self) -> &Self::Public {
+        &self.1
+    }
+}
+
+impl ConstantTimeEq for Bn254Keypair {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.secret().ct_eq(other.secret())
+    }
+}
+
+impl From<&Bn254Keypair> for Bn254PublicKey {
+    fn from(value: &Bn254Keypair) -> Self {
+        *value.public()
+    }
+}
+
 /// Extension trait for keypairs that can be used as PIX deposit/withdrawal keys.
 ///
 /// This trait is automatically implemented for all keypairs, where the public key is convertible into [`PixDepositAddress`]
@@ -367,5 +409,45 @@ mod tests {
         let (s1, p1) = kp_1.clone().unzip_into_pix();
         assert_eq!(s1.0.ct_eq(&kp_1.secret()).unwrap_u8(), 1);
         assert_eq!(p1, kp_1.public().clone().into());
+    }
+
+    #[test]
+    fn test_bn254_keypair() {
+        let kp_1 = Bn254Keypair::random();
+
+        let public = Bn254PublicKey::from_privkey(kp_1.secret().as_ref()).unwrap();
+        assert_eq!(
+            &public,
+            kp_1.public(),
+            "secret keys must yield compatible public keys"
+        );
+        assert_eq!(
+            public,
+            Bn254PublicKey::from(&kp_1),
+            "secret keys must yield compatible public keys"
+        );
+
+        let kp_2 = Bn254Keypair::from_secret(kp_1.secret().as_ref()).unwrap();
+        assert_eq!(
+            kp_1.ct_eq(&kp_2).unwrap_u8(),
+            1,
+            "keypairs generated from secrets must be equal"
+        );
+        assert_eq!(
+            &public,
+            kp_2.public(),
+            "secret keys must yield compatible public keys"
+        );
+        assert_eq!(
+            kp_1.public(),
+            kp_2.public(),
+            "keypair public keys must be equal"
+        );
+
+        let (s1, p1) = kp_1.clone().unzip();
+        let (s2, p2) = kp_2.clone().unzip();
+
+        assert_eq!(s1.ct_eq(&s2).unwrap_u8(), 1);
+        assert_eq!(p1, p2);
     }
 }

--- a/src/crypto/primitives.rs
+++ b/src/crypto/primitives.rs
@@ -12,6 +12,12 @@ pub type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
 
 use crate::crypto::prelude::{BjjPublicKey, PublicKey};
 use crate::primitive::prelude::{Address, GeneralError};
+/// BN254 curve, re-exported from the [`ark_bn254`] crate.
+pub use ark_bn254::{
+    Fr as Bn254Scalar, G1Affine as Bn254G1Affine, G1Projective as Bn254G1Projective,
+};
+/// Serialization traits, re-exported from the [`ark_serialize`] crate.
+pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 /// BabyJubJub elliptic curve, re-exported from the [`babyjubjub_ec`] crate.
 pub use babyjubjub_ec::{
     BabyJubJub, GroupRepr as BabyJubJubCompressedPoint, Scalar as BabyJubJubScalar,

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -1494,8 +1494,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bn254_public_key_rejects_invalid()
-    -> anyhow::Result<()> {
+    fn test_bn254_public_key_rejects_invalid() -> anyhow::Result<()> {
         use ark_ff::PrimeField;
 
         // Deserialization of invalid 32 bytes (identity point)

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -697,21 +697,50 @@ impl TryFrom<babyjubjub_ec::AffinePoint> for BjjPublicKey {
 
 /// Implements a public key for the BN254 curve (also known as alt-BN128).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Bn254PublicKey(
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))] [u8; Self::SIZE],
 );
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Bn254PublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = serde_bytes::ByteBuf::deserialize(deserializer)?;
+        Self::try_from(buf.as_ref()).map_err(serde::de::Error::custom)
+    }
+}
+
 impl Bn254PublicKey {
+    /// Derives a [`Bn254PublicKey`] from a little-endian 32-byte secret scalar.
+    ///
+    /// Returns [`CryptoError::InvalidSecretScalar`] if:
+    /// - the input is not exactly 32 bytes,
+    /// - the scalar is zero, or
+    /// - the scalar is greater than or equal to the BN254 Fr field modulus.
     pub fn from_privkey(secret: &[u8]) -> Result<Self> {
         use ark_ec::{AffineRepr, PrimeGroup};
+        use ark_ff::{BigInt, PrimeField};
         use ark_serialize::CanonicalSerialize;
 
         let bytes: [u8; 32] = secret
             .try_into()
             .map_err(|_| CryptoError::InvalidSecretScalar)?;
 
-        use ark_ff::PrimeField;
+        // Reject non-canonical scalars >= Fr::MODULUS.
+        // Using from_le_bytes_mod_order alone is not sufficient: s and s + r
+        // produce the same public key, but Bn254Keypair::secret() retains
+        // the unreduced bytes, creating key-consistency problems.
+        let mut limbs = [0u64; 4];
+        for (i, chunk) in bytes.chunks(8).enumerate() {
+            limbs[i] = u64::from_le_bytes(chunk.try_into().expect("8 bytes"));
+        }
+        if BigInt::<4>::new(limbs) >= ark_bn254::Fr::MODULUS {
+            return Err(CryptoError::InvalidSecretScalar);
+        }
+
         let scalar = ark_bn254::Fr::from_le_bytes_mod_order(&bytes);
         let point = ark_bn254::G1Projective::generator() * scalar;
         let affine = ark_bn254::G1Affine::from(point);
@@ -807,19 +836,23 @@ impl TryFrom<ark_bn254::G1Projective> for Bn254PublicKey {
     }
 }
 
-impl From<&Bn254PublicKey> for ark_bn254::G1Projective {
-    fn from(value: &Bn254PublicKey) -> ark_bn254::G1Projective {
+impl TryFrom<&Bn254PublicKey> for ark_bn254::G1Projective {
+    type Error = CryptoError;
+
+    fn try_from(value: &Bn254PublicKey) -> result::Result<ark_bn254::G1Projective, Self::Error> {
         use ark_serialize::CanonicalDeserialize;
 
         let affine = ark_bn254::G1Affine::deserialize_compressed(&value.0[..])
-            .expect("Bn254PublicKey is always valid");
-        affine.into()
+            .map_err(|_| CryptoError::InvalidPublicKey)?;
+        Ok(affine.into())
     }
 }
 
-impl From<Bn254PublicKey> for ark_bn254::G1Projective {
-    fn from(value: Bn254PublicKey) -> ark_bn254::G1Projective {
-        (&value).into()
+impl TryFrom<Bn254PublicKey> for ark_bn254::G1Projective {
+    type Error = CryptoError;
+
+    fn try_from(value: Bn254PublicKey) -> result::Result<ark_bn254::G1Projective, Self::Error> {
+        (&value).try_into()
     }
 }
 
@@ -1442,10 +1475,91 @@ mod tests {
         assert_eq!(Bn254PublicKey::from_str(&pk1.to_string())?, pk1);
 
         // Must reject identity point
-        assert!(Bn254PublicKey::try_from(ark_bn254::G1Projective::default()).is_err());
+        let identity = ark_bn254::G1Affine::identity();
+        assert!(
+            Bn254PublicKey::try_from(identity).is_err(),
+            "identity point must be rejected"
+        );
 
-        let proj: ark_bn254::G1Projective = pk1.into();
+        let proj: ark_bn254::G1Projective = (&pk1).try_into()?;
         assert_eq!(Bn254PublicKey::try_from(proj)?, pk1);
+
+        // TryFrom<G1Affine>
+        let proj2: ark_bn254::G1Projective = (&pk1).try_into()?;
+        let affine: ark_bn254::G1Affine = proj2.into();
+        let pk_from_affine = Bn254PublicKey::try_from(affine)?;
+        assert_eq!(pk1, pk_from_affine, "from G1Affine failed");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bn254_public_key_rejects_invalid()
+    -> anyhow::Result<()> {
+        use ark_ff::PrimeField;
+
+        // Deserialization of invalid 32 bytes (identity point)
+        assert!(
+            Bn254PublicKey::try_from(&[0u8; 32][..]).is_err(),
+            "all-zero 32 bytes must be rejected (identity)"
+        );
+
+        // Wrong-length slices
+        assert!(
+            Bn254PublicKey::try_from(&[0u8; 31][..]).is_err(),
+            "31 bytes must be rejected"
+        );
+        assert!(
+            Bn254PublicKey::try_from(&[0u8; 33][..]).is_err(),
+            "33 bytes must be rejected"
+        );
+
+        // from_privkey: zero secret
+        assert!(
+            Bn254PublicKey::from_privkey(&[0u8; 32]).is_err(),
+            "zero secret must be rejected"
+        );
+
+        // from_privkey: secret equal to Fr::MODULUS
+        let modulus_bytes_le: Vec<u8> = ark_bn254::Fr::MODULUS
+            .0
+            .iter()
+            .flat_map(|limb| limb.to_le_bytes())
+            .collect();
+        let modulus_arr: [u8; 32] = modulus_bytes_le.try_into().unwrap();
+        assert!(
+            Bn254PublicKey::from_privkey(&modulus_arr).is_err(),
+            "secret equal to Fr::MODULUS must be rejected"
+        );
+
+        // Also reject modulus + 1
+        let mut over_modulus = modulus_arr;
+        for byte in &mut over_modulus {
+            let (sum, overflow) = byte.overflowing_add(1);
+            *byte = sum;
+            if !overflow {
+                break;
+            }
+        }
+        assert!(
+            Bn254PublicKey::from_privkey(&over_modulus).is_err(),
+            "secret > Fr::MODULUS must be rejected"
+        );
+
+        // from_privkey: wrong length
+        assert!(
+            Bn254PublicKey::from_privkey(&[0u8; 31]).is_err(),
+            "31-byte secret must be rejected"
+        );
+        assert!(
+            Bn254PublicKey::from_privkey(&[0u8; 33]).is_err(),
+            "33-byte secret must be rejected"
+        );
+
+        // Round-trip: TryFrom<&Bn254PublicKey> for G1Projective
+        let (_, pk) = Bn254Keypair::random().unzip();
+        let proj: ark_bn254::G1Projective = (&pk).try_into()?;
+        let _ = Bn254PublicKey::try_from(&proj)?;
 
         Ok(())
     }

--- a/src/crypto/types.rs
+++ b/src/crypto/types.rs
@@ -695,6 +695,149 @@ impl TryFrom<babyjubjub_ec::AffinePoint> for BjjPublicKey {
     }
 }
 
+/// Implements a public key for the BN254 curve (also known as alt-BN128).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Bn254PublicKey(
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))] [u8; Self::SIZE],
+);
+
+impl Bn254PublicKey {
+    pub fn from_privkey(secret: &[u8]) -> Result<Self> {
+        use ark_ec::{AffineRepr, PrimeGroup};
+        use ark_serialize::CanonicalSerialize;
+
+        let bytes: [u8; 32] = secret
+            .try_into()
+            .map_err(|_| CryptoError::InvalidSecretScalar)?;
+
+        use ark_ff::PrimeField;
+        let scalar = ark_bn254::Fr::from_le_bytes_mod_order(&bytes);
+        let point = ark_bn254::G1Projective::generator() * scalar;
+        let affine = ark_bn254::G1Affine::from(point);
+
+        if affine.is_zero() {
+            return Err(CryptoError::InvalidSecretScalar);
+        }
+
+        let mut buf = [0u8; Self::SIZE];
+        affine
+            .serialize_compressed(&mut buf[..])
+            .map_err(|_| CryptoError::InvalidPublicKey)?;
+
+        Ok(Self(buf))
+    }
+}
+
+impl Display for Bn254PublicKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+impl FromStr for Bn254PublicKey {
+    type Err = GeneralError;
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl AsRef<[u8]> for Bn254PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Bn254PublicKey {
+    type Error = GeneralError;
+    fn try_from(value: &'a [u8]) -> result::Result<Self, Self::Error> {
+        if value.len() != Self::SIZE {
+            return Err(ParseError("Bn254PublicKey".into()));
+        }
+
+        let repr_bytes: [u8; 32] = value
+            .try_into()
+            .map_err(|_| ParseError("Bn254PublicKey".into()))?;
+
+        use ark_ec::AffineRepr;
+        use ark_serialize::CanonicalDeserialize;
+
+        let affine = ark_bn254::G1Affine::deserialize_compressed(&repr_bytes[..])
+            .map_err(|_| ParseError("Bn254PublicKey".into()))?;
+
+        if affine.is_zero() {
+            return Err(ParseError("Bn254PublicKey".into()));
+        }
+        // BN254 has cofactor=1 for G1, so any valid curve point is in the prime-order subgroup.
+
+        Ok(Self(repr_bytes))
+    }
+}
+
+impl BytesRepresentable for Bn254PublicKey {
+    const SIZE: usize = 32;
+}
+
+impl TryFrom<&ark_bn254::G1Projective> for Bn254PublicKey {
+    type Error = CryptoError;
+
+    fn try_from(value: &ark_bn254::G1Projective) -> result::Result<Self, Self::Error> {
+        use ark_ec::AffineRepr;
+        use ark_serialize::CanonicalSerialize;
+
+        let affine = ark_bn254::G1Affine::from(*value);
+        if affine.is_zero() {
+            return Err(CryptoError::InvalidPublicKey);
+        }
+
+        let mut buf = [0u8; Self::SIZE];
+        affine
+            .serialize_compressed(&mut buf[..])
+            .map_err(|_| CryptoError::InvalidPublicKey)?;
+
+        Ok(Self(buf))
+    }
+}
+
+impl TryFrom<ark_bn254::G1Projective> for Bn254PublicKey {
+    type Error = CryptoError;
+
+    fn try_from(value: ark_bn254::G1Projective) -> result::Result<Self, Self::Error> {
+        (&value).try_into()
+    }
+}
+
+impl From<&Bn254PublicKey> for ark_bn254::G1Projective {
+    fn from(value: &Bn254PublicKey) -> ark_bn254::G1Projective {
+        use ark_serialize::CanonicalDeserialize;
+
+        let affine = ark_bn254::G1Affine::deserialize_compressed(&value.0[..])
+            .expect("Bn254PublicKey is always valid");
+        affine.into()
+    }
+}
+
+impl From<Bn254PublicKey> for ark_bn254::G1Projective {
+    fn from(value: Bn254PublicKey) -> ark_bn254::G1Projective {
+        (&value).into()
+    }
+}
+
+impl TryFrom<&ark_bn254::G1Affine> for Bn254PublicKey {
+    type Error = CryptoError;
+
+    fn try_from(value: &ark_bn254::G1Affine) -> result::Result<Self, Self::Error> {
+        (ark_bn254::G1Projective::from(*value)).try_into()
+    }
+}
+
+impl TryFrom<ark_bn254::G1Affine> for Bn254PublicKey {
+    type Error = CryptoError;
+    fn try_from(value: ark_bn254::G1Affine) -> result::Result<Self, Self::Error> {
+        (&value).try_into()
+    }
+}
+
 /// Length of a packet tag
 pub const PACKET_TAG_LENGTH: usize = 16;
 
@@ -1164,7 +1307,7 @@ mod tests {
     use libp2p_identity::PeerId;
     use std::str::FromStr;
 
-    use crate::crypto::prelude::BjjKeypair;
+    use crate::crypto::prelude::{BjjKeypair, Bn254Keypair, Bn254PublicKey};
     use crate::crypto::types::BjjPublicKey;
     use crate::crypto::{
         keypairs::{Keypair, OffchainKeypair},
@@ -1282,6 +1425,27 @@ mod tests {
 
         let proj: babyjubjub_ec::ProjectivePoint = pk1.into();
         assert_eq!(BjjPublicKey::try_from(proj)?, pk1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bn254_public_key() -> anyhow::Result<()> {
+        let (s, pk1) = Bn254Keypair::random().unzip();
+
+        let pk2 = Bn254PublicKey::from_privkey(s.as_ref())?;
+        assert_eq!(pk1, pk2, "from privkey failed");
+
+        let pk3 = Bn254PublicKey::try_from(pk1.as_ref())?;
+        assert_eq!(pk1, pk3, "from bytes failed");
+
+        assert_eq!(Bn254PublicKey::from_str(&pk1.to_string())?, pk1);
+
+        // Must reject identity point
+        assert!(Bn254PublicKey::try_from(ark_bn254::G1Projective::default()).is_err());
+
+        let proj: ark_bn254::G1Projective = pk1.into();
+        assert_eq!(Bn254PublicKey::try_from(proj)?, pk1);
 
         Ok(())
     }


### PR DESCRIPTION
Add `Bn254PublicKey` and `Bn254Keypair` types using the `ark-bn254` crate as the backend, following the existing `BjjPublicKey` / `BjjKeypair` pattern.

## Changes

- **Cargo.toml**: Add `ark-bn254`, `ark-ec`, `ark-ff`, `ark-serialize` optional deps
- **types.rs**: `Bn254PublicKey` — newtype `[u8; 32]` with `from_privkey` (GENERATOR × scalar), `TryFrom<&[u8]>` with identity-point validation, full conversions to/from `G1Projective` and `G1Affine`
- **keypairs.rs**: `Bn254Keypair` — wraps `(SecretValue<U32>, Bn254PublicKey)`, implements `Keypair` trait with rejection-sampling `random()`
- **primitives.rs**: Re-export BN254 curve types (`Bn254Scalar`, `Bn254G1Affine`, `Bn254G1Projective`)

Refs [#8344](https://github.com/hoprnet/hoprnet/issues/8344)